### PR TITLE
8334179: VMATreeTest.TestConsistencyWithSimpleTracker_vm runs 50+ seconds

### DIFF
--- a/test/hotspot/gtest/nmt/test_vmatree.cpp
+++ b/test/hotspot/gtest/nmt/test_vmatree.cpp
@@ -358,7 +358,7 @@ struct SimpleVMATracker : public CHeapObj<mtTest> {
     }
   };
   // Page (4KiB) granular array
-  static constexpr const size_t num_pages = 1024 * 512;
+  static constexpr const size_t num_pages = 1024 * 4;
   Info pages[num_pages];
 
   SimpleVMATracker()
@@ -434,8 +434,6 @@ TEST_VM_F(VMATreeTest, TestConsistencyWithSimpleTracker) {
   const MEMFLAGS candidate_flags[candidates_len_flags] = {
     mtNMT,
     mtTest,
-    mtGC,
-    mtCompiler
   };
 
   const int operation_count = 100000; // One hundred thousand


### PR DESCRIPTION
This pull request contains a backport of commit [5528ad74](https://github.com/openjdk/jdk/commit/5528ad74902fa4f4ec621d70e7e7d85f4ac1d780) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 13 Jun 2024 and was reviewed by Johan Sjölen.

This fixes a performance problem in gtests that more than triples time for a single run. The fix is simple and benign.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8334179](https://bugs.openjdk.org/browse/JDK-8334179) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334179](https://bugs.openjdk.org/browse/JDK-8334179): VMATreeTest.TestConsistencyWithSimpleTracker_vm runs 50+ seconds (**Bug** - P3 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/3.diff">https://git.openjdk.org/jdk23u/pull/3.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/3#issuecomment-2165047193)