### PR TITLE
6967482: TAB-key does not work in JTables after selecting details-view in JFileChooser

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/FilePane.java
+++ b/src/java.desktop/share/classes/sun/swing/FilePane.java
@@ -1317,13 +1317,6 @@ public class FilePane extends JPanel implements PropertyChangeListener {
             detailsTable.addFocusListener(repaintListener);
         }
 
-        // TAB/SHIFT-TAB should transfer focus and ENTER should select an item.
-        // We don't want them to navigate within the table
-        ActionMap am = SwingUtilities.getUIActionMap(detailsTable);
-        am.remove("selectNextRowCell");
-        am.remove("selectPreviousRowCell");
-        am.remove("selectNextColumnCell");
-        am.remove("selectPreviousColumnCell");
         detailsTable.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS,
                      null);
         detailsTable.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS,

--- a/test/jdk/javax/swing/JFileChooser/TABTestONFCExit.java
+++ b/test/jdk/javax/swing/JFileChooser/TABTestONFCExit.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Point;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import javax.swing.AbstractButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JTable;
+import javax.swing.JToggleButton;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+import javax.swing.UIManager;
+import javax.swing.table.DefaultTableModel;
+
+import java.util.function.Predicate;
+
+/*
+ * @test
+ * @bug 6967482
+ * @key headful
+ * @summary Test to check if TAB is working on JTable after JFileChooser is
+ *          closed
+ * @run main TABTestONFCExit
+ */
+
+public class TABTestONFCExit {
+    private static JTable table;
+    private static JFileChooser fc;
+    private static JFrame frame;
+    private static Robot robot;
+    private static volatile Point loc;
+    private static volatile Rectangle rect;
+    private static volatile int selectedColumnBeforeTabPress;
+    private static volatile int selectedColumnAfterTabPress;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(50);
+        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+        try {
+            SwingUtilities.invokeAndWait(TABTestONFCExit::initialize);
+            robot.waitForIdle();
+            robot.delay(100);
+
+            SwingUtilities.invokeAndWait(TABTestONFCExit::clickDetails);
+            robot.waitForIdle();
+            robot.delay(100);
+
+            SwingUtilities.invokeAndWait(() -> {
+                loc = table.getLocationOnScreen();
+                rect = table.getCellRect(0, 0, true);
+            });
+
+            onClick(loc, rect);
+
+            SwingUtilities.invokeAndWait(() ->
+                    selectedColumnBeforeTabPress = table.getSelectedColumn());
+
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.waitForIdle();
+            robot.delay(100);
+
+            SwingUtilities.invokeAndWait(() ->
+                    selectedColumnAfterTabPress = table.getSelectedColumn());
+            robot.waitForIdle();
+            robot.delay(100);
+
+            if (selectedColumnAfterTabPress == selectedColumnBeforeTabPress) {
+                throw new RuntimeException("TAB failed to move cell!");
+            }
+            System.out.println("Test Passed" );
+
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void onClick(Point loc, Rectangle cellRect) {
+        robot.mouseMove(loc.x + cellRect.x + cellRect.width / 2,
+                loc.y + cellRect.y + cellRect.height / 2);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        robot.delay(100);
+    }
+
+    private static void initialize() {
+        frame = new JFrame("Tab Test");
+        fc = new JFileChooser();
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.add(getJTable(), BorderLayout.NORTH);
+        frame.add(fc, BorderLayout.SOUTH);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    private static JTable getJTable() {
+        if (table == null) {
+            table = new JTable();
+            table.setModel(new DefaultTableModel(5, 5));
+        }
+        return table;
+    }
+    private static void clickDetails() {
+        AbstractButton details = findDetailsButton(fc);
+        if (details == null) {
+            throw new Error("Couldn't find 'Details' button in JFileChooser");
+        }
+        details.doClick();
+    }
+
+    private static AbstractButton findDetailsButton(final Container container) {
+        Component result = findComponent(container,
+                c -> c instanceof JToggleButton button
+                        && "Details".equals(button.getToolTipText()));
+        return (AbstractButton) result;
+    }
+
+    private static Component findComponent(final Container container,
+                                           final Predicate<Component> predicate) {
+        for (Component child : container.getComponents()) {
+            if (predicate.test(child)) {
+                return child;
+            }
+            if (child instanceof Container cont && cont.getComponentCount() > 0) {
+                Component result = findComponent(cont, predicate);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Backporting [JDK-6967482](https://bugs.openjdk.org/browse/JDK-6967482) to 21u.

The patch applies cleanly.

> This pull request contains a backport of commit [711e7238](https://github.com/openjdk/jdk/commit/711e7238196a4ef9211ed4cca15c7c1d774df019) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
> 
> The commit being backported was authored by Tejesh R on 21 Jun 2024 and was reviewed by Alisen Chung and Phil Race.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-6967482](https://bugs.openjdk.org/browse/JDK-6967482) needs maintainer approval
- [x] [JDK-8166352](https://bugs.openjdk.org/browse/JDK-8166352) needs maintainer approval

### Issues
 * [JDK-6967482](https://bugs.openjdk.org/browse/JDK-6967482): TAB-key does not work in JTables after selecting details-view in JFileChooser (**Bug** - P3 - Approved)
 * [JDK-8166352](https://bugs.openjdk.org/browse/JDK-8166352): FilePane.createDetailsView() removes JTable TAB, SHIFT-TAB functionality (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/6.diff">https://git.openjdk.org/jdk23u/pull/6.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/6#issuecomment-2187180882)