### PR TITLE
8333716: Shenandoah: Check for disarmed method before taking the nmethod lock

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
@@ -36,13 +36,19 @@
 #include "runtime/threadWXSetters.inline.hpp"
 
 bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
+  if (!is_armed(nm)) {
+    // Some other thread got here first and healed the oops
+    // and disarmed the nmethod. No need to continue.
+    return true;
+  }
+
   ShenandoahReentrantLock* lock = ShenandoahNMethod::lock_for_nmethod(nm);
   assert(lock != nullptr, "Must be");
   ShenandoahReentrantLocker locker(lock);
 
   if (!is_armed(nm)) {
-    // Some other thread got here first and healed the oops
-    // and disarmed the nmethod.
+    // Some other thread managed to complete while we were
+    // waiting for lock. No need to continue.
     return true;
   }
 


### PR DESCRIPTION
Backport of [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716).
Change has already been backported to 21 and 17.

**Testing**
1. hotspot_gc tests

2. Benchmarking on [c6a.12xlarge](https://aws.amazon.com/ec2/instance-types/c6a/)
Prior to PR:
```
dev-dsk-neethp-jdk-2c-ad54955c % jdk23u/build/linux-x86_64-server-release/images/jdk/bin/java -Xmx1g -Xms1g -XX:+UseShenandoahGC -Xlog:gc ManyThreadsStacks.java 2>&1 | grep "marking roots"
[0.666s][info][gc] GC(0) Concurrent marking roots 70.709ms
[0.769s][info][gc] GC(1) Concurrent marking roots 77.658ms
[0.876s][info][gc] GC(2) Concurrent marking roots 86.840ms
[0.966s][info][gc] GC(3) Concurrent marking roots 72.479ms
[1.066s][info][gc] GC(4) Concurrent marking roots 82.360ms
[1.272s][info][gc] GC(5) Concurrent marking roots 76.854ms
[1.403s][info][gc] GC(6) Concurrent marking roots 81.824ms
[1.541s][info][gc] GC(7) Concurrent marking roots 83.342ms
[1.686s][info][gc] GC(8) Concurrent marking roots 89.838ms
[1.849s][info][gc] GC(9) Concurrent marking roots 88.486ms
[2.001s][info][gc] GC(10) Concurrent marking roots 78.584ms
[2.143s][info][gc] GC(11) Concurrent marking roots 85.297ms
[2.280s][info][gc] GC(12) Concurrent marking roots 78.562ms
[2.409s][info][gc] GC(13) Concurrent marking roots 78.005ms
[2.543s][info][gc] GC(14) Concurrent marking roots 77.846ms
[2.682s][info][gc] GC(15) Concurrent marking roots 88.989ms
[2.816s][info][gc] GC(16) Concurrent marking roots 81.305ms
[2.954s][info][gc] GC(17) Concurrent marking roots 73.452ms
[3.084s][info][gc] GC(18) Concurrent marking roots 71.614ms
```


After PR:

```
dev-dsk-neethp-jdk-2c-ad54955c % jdk23u/build/linux-x86_64-server-release/images/jdk/bin/java -Xmx1g -Xms1g -XX:+UseShenandoahGC -Xlog:gc ManyThreadsStacks.java 2>&1 | grep "marking roots"
[0.620s][info][gc] GC(0) Concurrent marking roots 5.057ms
[0.645s][info][gc] GC(1) Concurrent marking roots 3.123ms
[0.669s][info][gc] GC(2) Concurrent marking roots 3.256ms
[0.690s][info][gc] GC(3) Concurrent marking roots 2.654ms
[0.712s][info][gc] GC(4) Concurrent marking roots 2.518ms
[0.944s][info][gc] GC(5) Concurrent marking roots 3.363ms
[1.016s][info][gc] GC(6) Concurrent marking roots 2.768ms
[1.085s][info][gc] GC(7) Concurrent marking roots 2.461ms
[1.154s][info][gc] GC(8) Concurrent marking roots 2.800ms
[1.224s][info][gc] GC(9) Concurrent marking roots 3.097ms
[1.295s][info][gc] GC(10) Concurrent marking roots 2.878ms
[1.365s][info][gc] GC(11) Concurrent marking roots 2.745ms
[1.436s][info][gc] GC(12) Concurrent marking roots 3.011ms
[1.506s][info][gc] GC(13) Concurrent marking roots 3.098ms
[1.577s][info][gc] GC(14) Concurrent marking roots 3.157ms
[1.646s][info][gc] GC(15) Concurrent marking roots 2.732ms
[1.717s][info][gc] GC(16) Concurrent marking roots 2.572ms
[1.788s][info][gc] GC(17) Concurrent marking roots 2.899ms
[1.858s][info][gc] GC(18) Concurrent marking roots 2.800ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716) needs maintainer approval

### Issue
 * [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716): Shenandoah: Check for disarmed method before taking the nmethod lock (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/9.diff">https://git.openjdk.org/jdk23u/pull/9.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/9#issuecomment-2190224409)