### PR TITLE
8332113: Update nsk.share.Log to be always verbose

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -74,15 +74,15 @@ public class Log {
 
     /**
      * Is log-mode verbose?
-     * Default value is <code>false</code>.
+     * Always enabled.
      */
-    private boolean verbose = false;
+    private final boolean verbose = true;
 
     /**
      * Should log messages prefixed with timestamps?
-     * Default value is <code>false</code>.
+     * Always enabled.
      */
-    private boolean timestamp = false;
+    private final boolean timestamp = true;
 
     /**
      * Names for trace levels
@@ -193,7 +193,6 @@ public class Log {
      */
     public Log(PrintStream stream, boolean verbose) {
         this(stream);
-        this.verbose = verbose;
     }
 
     /**
@@ -204,7 +203,6 @@ public class Log {
     public Log(PrintStream stream, ArgumentParser argsParser) {
         this(stream, argsParser.verbose());
         traceLevel = argsParser.getTraceLevel();
-        timestamp = argsParser.isTimestamp();
     }
 
     /////////////////////////////////////////////////////////////////
@@ -220,10 +218,9 @@ public class Log {
      * Enable or disable verbose mode for printing messages.
      */
     public void enableVerbose(boolean enable) {
-        if (!verbose) {
-            flushLogBuffer();
+        if (!enable) {
+            throw new RuntimeException("The non-verbose logging is not supported.");
         }
-        verbose = enable;
     }
 
     public int getTraceLevel() {
@@ -422,7 +419,6 @@ public class Log {
             out.flush();
         }
         out = stream;
-        verbose = true;
     }
 
     /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Tested Tier 1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332113](https://bugs.openjdk.org/browse/JDK-8332113) needs maintainer approval

### Issue
 * [JDK-8332113](https://bugs.openjdk.org/browse/JDK-8332113): Update nsk.share.Log to be always verbose (**Enhancement** - P4 - Approved)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - Author)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/11.diff">https://git.openjdk.org/jdk23u/pull/11.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/11#issuecomment-2191267848)