### PR TITLE
8335536: Fix assertion failure in IdealGraphPrinter when append is true

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -96,6 +96,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   bool _traverse_outs;
   Compile *C;
   double _max_freq;
+  bool _append;
 
   void print_method(ciMethod* method, int bci, InlineTree* tree);
   void print_inline_tree(InlineTree* tree);
@@ -118,7 +119,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   void head(const char *name);
   void text(const char *s);
   void init(const char* file_name, bool use_multiple_files, bool append);
-  void init_file_stream(const char* file_name, bool use_multiple_files, bool append);
+  void init_file_stream(const char* file_name, bool use_multiple_files);
   void init_network_stream();
   IdealGraphPrinter();
   ~IdealGraphPrinter();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6db4c6a7](https://github.com/openjdk/jdk/commit/6db4c6a772df856fc3099c32a5b2c102a30d360c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Qizheng Xing on 3 Jul 2024 and was reviewed by Tobias Hartmann, Christian Hagedorn and Tobias Holenstein.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8335536](https://bugs.openjdk.org/browse/JDK-8335536) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335536](https://bugs.openjdk.org/browse/JDK-8335536): Fix assertion failure in IdealGraphPrinter when append is true (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/14.diff">https://git.openjdk.org/jdk23u/pull/14.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/14#issuecomment-2210323310)