### PR TITLE
8334123: log the opening of Type 1 fonts

### DIFF
--- a/src/java.desktop/share/classes/sun/font/Type1Font.java
+++ b/src/java.desktop/share/classes/sun/font/Type1Font.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,9 @@ public class Type1Font extends FileFont {
     private synchronized ByteBuffer getBuffer() throws FontFormatException {
         ByteBuffer bbuf = bufferRef.get();
         if (bbuf == null) {
-          //System.out.println("open T1 " + platName);
+            if (FontUtilities.isLogging()) {
+                FontUtilities.logInfo("open Type 1 font: " + platName);
+            }
             try {
                 @SuppressWarnings("removal")
                 RandomAccessFile raf = (RandomAccessFile)
@@ -229,6 +231,9 @@ public class Type1Font extends FileFont {
     void readFile(ByteBuffer buffer) {
         RandomAccessFile raf = null;
         FileChannel fc;
+        if (FontUtilities.isLogging()) {
+            FontUtilities.logInfo("open Type 1 font: " + platName);
+        }
         try {
             raf = (RandomAccessFile)
                 java.security.AccessController.doPrivileged(


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334123](https://bugs.openjdk.org/browse/JDK-8334123) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8334123: log the opening of Type 1 fonts`

### Issue
 * [JDK-8334123](https://bugs.openjdk.org/browse/JDK-8334123): log the opening of Type 1 fonts (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/17.diff">https://git.openjdk.org/jdk23u/pull/17.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/17#issuecomment-2213752954)