### PR TITLE
8333887: ubsan: unsafe.cpp:247:13: runtime error: store to null pointer of type 'volatile int'

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -242,6 +242,11 @@ public:
     return normalize_for_read(*addr());
   }
 
+  // we use this method at some places for writing to 0 e.g. to cause a crash;
+  // ubsan does not know that this is the desired behavior
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
   void put(T x) {
     GuardUnsafeAccess guard(_thread);
     *addr() = normalize_for_write(x);


### PR DESCRIPTION
hi ，

This pull request contains a backport of commit [0d3a3771](https://git.openjdk.org/jdk/commit/0d3a3771c3777d3dd1fec8dc8faed5fd02b06830) from the [master](https://github.com/openjdk/jdk) repository.

The commit being backported was authored by Matthias Baesken on 13 Jun 2024.

Thanks！

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333887](https://bugs.openjdk.org/browse/JDK-8333887) needs maintainer approval

### Issue
 * [JDK-8333887](https://bugs.openjdk.org/browse/JDK-8333887): ubsan: unsafe.cpp:247:13: runtime error: store to null pointer of type 'volatile int' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/22.diff">https://git.openjdk.org/jdk23u/pull/22.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/22#issuecomment-2227637003)