### PR TITLE
Backport 6861766b638c5135ba40f261d78d9731954ce5ab

### DIFF
--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -61,6 +61,9 @@ ptrdiff_t ArchiveHeapLoader::_mapped_heap_delta = 0;
 
 // Every mapped region is offset by _mapped_heap_delta from its requested address.
 // See FileMapInfo::heap_region_requested_address().
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
 void ArchiveHeapLoader::init_mapped_heap_info(address mapped_heap_bottom, ptrdiff_t delta, int dumptime_oop_shift) {
   assert(!_mapped_heap_relocation_initialized, "only once");
   if (!UseCompressedOops) {


### PR DESCRIPTION
Hi ，

This pull request contains a backport of commit [6861766b](https://git.openjdk.org/jdk/commit/6861766b638c5135ba40f261d78d9731954ce5ab) from the [master](https://github.com/openjdk/jdk) repository.

The commit being backported was authored by Matthias Baesken on 14 Jun 2024.

Thanks！