### PR TITLE
8335493: check_gc_overhead_limit should reset SoftRefPolicy::_should_clear_all_soft_refs

### DIFF
--- a/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
+++ b/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
@@ -40,7 +40,11 @@ void GCOverheadChecker::check_gc_overhead_limit(GCOverheadTester* time_overhead,
                                                 bool is_full_gc,
                                                 GCCause::Cause gc_cause,
                                                 SoftRefPolicy* soft_ref_policy) {
-
+  if (is_full_gc) {
+    // Explicit Full GC would do the clearing of soft-refs as well
+    // So reset in the beginning
+    soft_ref_policy->set_should_clear_all_soft_refs(false);
+  }
   // Ignore explicit GC's.  Exiting here does not set the flag and
   // does not reset the count.
   if (GCCause::is_user_requested_gc(gc_cause) ||


### PR DESCRIPTION
Clean backport of fixing soft-ref resetting in Parallel Full GC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335493](https://bugs.openjdk.org/browse/JDK-8335493) needs maintainer approval

### Issue
 * [JDK-8335493](https://bugs.openjdk.org/browse/JDK-8335493): check_gc_overhead_limit should reset SoftRefPolicy::_should_clear_all_soft_refs (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/29.diff">https://git.openjdk.org/jdk23u/pull/29.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/29#issuecomment-2242423271)