### PR TITLE
8335283: Build failure due to 'no_sanitize' attribute directive ignored

### DIFF
--- a/src/hotspot/share/sanitizers/ub.hpp
+++ b/src/hotspot/share/sanitizers/ub.hpp
@@ -32,8 +32,10 @@
 // following function or method.
 // Useful if the function or method is known to do something special or even 'dangerous', for
 // example causing desired signals/crashes.
+#ifdef UNDEFINED_BEHAVIOR_SANITIZER
 #if defined(__clang__) || defined(__GNUC__)
 #define ATTRIBUTE_NO_UBSAN __attribute__((no_sanitize("undefined")))
+#endif
 #endif
 
 #ifndef ATTRIBUTE_NO_UBSAN


### PR DESCRIPTION
Hi @shipilev ，
This pull request contains a backport of commit [53242cdf](https://github.com/openjdk/jdk/commit/53242cdf9ef17c502ebd541e84370e7c158639c1) from the [master](https://github.com/openjdk/jdk) repository.

The commit being backported was authored by Matthias Baesken on 1 July 2024.

Thanks！

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335283](https://bugs.openjdk.org/browse/JDK-8335283) needs maintainer approval

### Issue
 * [JDK-8335283](https://bugs.openjdk.org/browse/JDK-8335283): Build failure due to 'no_sanitize' attribute directive ignored (**Bug** - P3 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/31.diff">https://git.openjdk.org/jdk23u/pull/31.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/31#issuecomment-2244351020)