### PR TITLE
8333277: ubsan: mlib_ImageScanPoly.c:292:43: runtime error: division by zero

### DIFF
--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageScanPoly.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageScanPoly.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -289,12 +289,14 @@ mlib_status mlib_AffineEdges(mlib_affine_param *param,
     mlib_d64 dX1 = coords[(topIdx - i) & 0x3][0];
     mlib_d64 dY2 = coords[(topIdx - i - 1) & 0x3][1];
     mlib_d64 dX2 = coords[(topIdx - i - 1) & 0x3][0];
-    mlib_d64 x = dX1, slope = (dX2 - dX1) / (dY2 - dY1);
+    mlib_d64 x = dX1, slope;
     mlib_s32 y1;
     mlib_s32 y2;
 
     if (dY1 == dY2)
       continue;
+
+    slope = (dX2 - dX1) / (dY2 - dY1);
 
     if (!(IS_FINITE(slope))) {
       continue;
@@ -330,12 +332,14 @@ mlib_status mlib_AffineEdges(mlib_affine_param *param,
     mlib_d64 dX1 = coords[(topIdx + i) & 0x3][0];
     mlib_d64 dY2 = coords[(topIdx + i + 1) & 0x3][1];
     mlib_d64 dX2 = coords[(topIdx + i + 1) & 0x3][0];
-    mlib_d64 x = dX1, slope = (dX2 - dX1) / (dY2 - dY1);
+    mlib_d64 x = dX1, slope;
     mlib_s32 y1;
     mlib_s32 y2;
 
     if (dY1 == dY2)
       continue;
+
+    slope = (dX2 - dX1) / (dY2 - dY1);
 
     if (!(IS_FINITE(slope))) {
       continue;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8333277](https://bugs.openjdk.org/browse/JDK-8333277) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333277](https://bugs.openjdk.org/browse/JDK-8333277): ubsan: mlib_ImageScanPoly.c:292:43: runtime error: division by zero (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/37.diff">https://git.openjdk.org/jdk23u/pull/37.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/37#issuecomment-2252640812)