### PR TITLE
8333730: ubsan: FieldIndices/libFieldIndicesTest.cpp:276:11: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp
@@ -273,7 +273,9 @@ void Klass::explore_interfaces(JNIEnv* env) {
   if (super_klass != nullptr) {
     // Add all interfaces implemented by super_klass first.
     interface_count = super_klass->interface_count;
-    memcpy(interfaces, super_klass->interfaces, sizeof(Klass*) * super_klass->interface_count);
+    if (super_klass->interfaces != nullptr) {
+      memcpy(interfaces, super_klass->interfaces, sizeof(Klass*) * super_klass->interface_count);
+    }
   }
 
   // Interfaces implemented by the klass.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333730](https://bugs.openjdk.org/browse/JDK-8333730) needs maintainer approval

### Issue
 * [JDK-8333730](https://bugs.openjdk.org/browse/JDK-8333730): ubsan: FieldIndices/libFieldIndicesTest.cpp:276:11: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/38.diff">https://git.openjdk.org/jdk23u/pull/38.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/38#issuecomment-2252648121)