### PR TITLE
8336315: tools/jpackage/windows/WinChildProcessTest.java Failed: Check is calculator process is alive

### DIFF
--- a/test/jdk/tools/jpackage/apps/ChildProcessAppLauncher.java
+++ b/test/jdk/tools/jpackage/apps/ChildProcessAppLauncher.java
@@ -26,12 +26,17 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 public class ChildProcessAppLauncher {
-
-    public static void main(String[] args) throws IOException {
-            String calcPath = Path.of(System.getenv("SystemRoot"), "system32", "calc.exe").toString();
-            ProcessBuilder processBuilder = new ProcessBuilder(calcPath);
+    public static void main(String[] args) throws IOException, InterruptedException {
+        if (args.length == 1 && "noexit".equals(args[0])) {
+            var lock = new Object();
+            synchronized (lock) {
+                lock.wait();
+            }
+        } else {
+            var childPath = System.getProperty("jpackage.app-path"); // get the path to the current jpackage app launcher
+            ProcessBuilder processBuilder = new ProcessBuilder(childPath, "noexit"); //ChildProcessAppLauncher acts as third party app
             Process process = processBuilder.start();
-            System.out.println("Calc id=" + process.pid());
-            System.exit(0);
+            System.out.println("Child id=" + process.pid());
+        }
     }
 }

--- a/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
+++ b/test/jdk/tools/jpackage/windows/WinChildProcessTest.java
@@ -53,7 +53,7 @@ public class WinChildProcessTest {
 
     @Test
     public static void test() throws Throwable {
-        long calcPid = 0;
+        long childPid = 0;
         try {
             JPackageCommand cmd = JPackageCommand
                     .helloAppImage(TEST_APP_JAVA + "*Hello");
@@ -68,21 +68,20 @@ public class WinChildProcessTest {
                     .execute(0).getOutput();
             String pidStr = output.get(0);
 
-            // parse calculator PID
-            calcPid = Long.parseLong(pidStr.split("=", 2)[1]);
+            // parse child PID
+            childPid = Long.parseLong(pidStr.split("=", 2)[1]);
 
             // Check whether the termination of third party application launcher
             // also terminating the launched third party application
             // If third party application is not terminated the test is
             // successful else failure
-            Optional<ProcessHandle> processHandle = ProcessHandle.of(calcPid);
+            Optional<ProcessHandle> processHandle = ProcessHandle.of(childPid);
             boolean isAlive = processHandle.isPresent()
                     && processHandle.get().isAlive();
-            System.out.println("Is Alive " + isAlive);
-            TKit.assertTrue(isAlive, "Check is calculator process is alive");
+            TKit.assertTrue(isAlive, "Check is child process is alive");
         } finally {
-            // Kill only a specific calculator instance
-            Runtime.getRuntime().exec("taskkill /F /PID " + calcPid);
+            // Kill only a specific child instance
+            Runtime.getRuntime().exec("taskkill /F /PID " + childPid);
         }
     }
 }


### PR DESCRIPTION
It is a clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336315](https://bugs.openjdk.org/browse/JDK-8336315) needs maintainer approval

### Issue
 * [JDK-8336315](https://bugs.openjdk.org/browse/JDK-8336315): tools/jpackage/windows/WinChildProcessTest.java Failed: Check is calculator process is alive (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/51.diff">https://git.openjdk.org/jdk23u/pull/51.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/51#issuecomment-2262889911)