### PR TITLE
8337283: configure.log is truncated when build dir is on different filesystem

### DIFF
--- a/make/autoconf/configure.ac
+++ b/make/autoconf/configure.ac
@@ -313,9 +313,11 @@ AC_OUTPUT
 
 # After AC_OUTPUT, we need to do final work
 CUSTOM_CONFIG_OUTPUT_GENERATED_HOOK
-BASIC_POST_CONFIG_OUTPUT
 
 # Finally output some useful information to the user
 HELP_PRINT_SUMMARY_AND_WARNINGS
 CUSTOM_SUMMARY_AND_WARNINGS_HOOK
 HELP_REPEAT_WARNINGS
+
+# All output is done. Do the post-config output management.
+BASIC_POST_CONFIG_OUTPUT


### PR DESCRIPTION
Keeps `configure.log` nice and complete. I have been running with this patch for more than a week in 23u builds, and there were no problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337283](https://bugs.openjdk.org/browse/JDK-8337283) needs maintainer approval

### Issue
 * [JDK-8337283](https://bugs.openjdk.org/browse/JDK-8337283): configure.log is truncated when build dir is on different filesystem (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/53.diff">https://git.openjdk.org/jdk23u/pull/53.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/53#issuecomment-2269605091)