### PR TITLE
Backport 1fe3ada001e188754df5de00bf6804f028ad274b

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestClhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestClhsdbJstackLock.java
@@ -59,7 +59,7 @@ public class TestClhsdbJstackLock {
                 "^\\s+- waiting to lock <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$",
                 "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Thread\\)$",
                 "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$",
-                "^\\s+- waiting on <0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)$"));
+                "^\\s+- waiting on (<0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)|<no object reference available>)$"));
             unExpStrMap.put("jstack", List.of(
                 "missing reason for "));
             test.run(app.getPid(), cmds, expStrMap, unExpStrMap);

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
@@ -65,7 +65,7 @@ public class TestJhsdbJstackLock {
             out.shouldMatch("^\\s+- waiting to lock <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$");
             out.shouldMatch("^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Thread\\)$");
             out.shouldMatch("^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$");
-            out.shouldMatch("^\\s+- waiting on <0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)$");
+            out.shouldMatch("^\\s+- waiting on (<0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)|<no object reference available>)$");
 
             out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
 


### PR DESCRIPTION
Hi all,
This pull request is the backport of JDK-8336284 .
It is clean. This change resolves a test failure introduced by JDK-8335743.
JDK-8335743 will be backported in https://github.com/openjdk/jdk23u/pull/59.
I verified that TestClhsdbJstackLock.java and TestJhsdbJstackLock.java are passed with -Xcomp.