### PR TITLE
8335007: Inline OopMapCache table

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -433,29 +433,25 @@ inline unsigned int OopMapCache::hash_value_for(const methodHandle& method, int 
 OopMapCacheEntry* volatile OopMapCache::_old_entries = nullptr;
 
 OopMapCache::OopMapCache() {
-  _array  = NEW_C_HEAP_ARRAY(OopMapCacheEntry*, _size, mtClass);
-  for(int i = 0; i < _size; i++) _array[i] = nullptr;
+  for(int i = 0; i < size; i++) _array[i] = nullptr;
 }
 
 
 OopMapCache::~OopMapCache() {
-  assert(_array != nullptr, "sanity check");
   // Deallocate oop maps that are allocated out-of-line
   flush();
-  // Deallocate array
-  FREE_C_HEAP_ARRAY(OopMapCacheEntry*, _array);
 }
 
 OopMapCacheEntry* OopMapCache::entry_at(int i) const {
-  return Atomic::load_acquire(&(_array[i % _size]));
+  return Atomic::load_acquire(&(_array[i % size]));
 }
 
 bool OopMapCache::put_at(int i, OopMapCacheEntry* entry, OopMapCacheEntry* old) {
-  return Atomic::cmpxchg(&_array[i % _size], old, entry) == old;
+  return Atomic::cmpxchg(&_array[i % size], old, entry) == old;
 }
 
 void OopMapCache::flush() {
-  for (int i = 0; i < _size; i++) {
+  for (int i = 0; i < size; i++) {
     OopMapCacheEntry* entry = _array[i];
     if (entry != nullptr) {
       _array[i] = nullptr;  // no barrier, only called in OopMapCache destructor
@@ -466,7 +462,7 @@ void OopMapCache::flush() {
 
 void OopMapCache::flush_obsolete_entries() {
   assert(SafepointSynchronize::is_at_safepoint(), "called by RedefineClasses in a safepoint");
-  for (int i = 0; i < _size; i++) {
+  for (int i = 0; i < size; i++) {
     OopMapCacheEntry* entry = _array[i];
     if (entry != nullptr && !entry->is_empty() && entry->method()->is_old()) {
       // Cache entry is occupied by an old redefined method and we don't want
@@ -501,7 +497,7 @@ void OopMapCache::lookup(const methodHandle& method,
   // Need a critical section to avoid race against concurrent reclamation.
   {
     GlobalCounter::CriticalSection cs(Thread::current());
-    for (int i = 0; i < _probe_depth; i++) {
+    for (int i = 0; i < probe_depth; i++) {
       OopMapCacheEntry *entry = entry_at(probe + i);
       if (entry != nullptr && !entry->is_empty() && entry->match(method, bci)) {
         entry_for->copy_from(entry);
@@ -530,7 +526,7 @@ void OopMapCache::lookup(const methodHandle& method,
   }
 
   // First search for an empty slot
-  for (int i = 0; i < _probe_depth; i++) {
+  for (int i = 0; i < probe_depth; i++) {
     OopMapCacheEntry* entry = entry_at(probe + i);
     if (entry == nullptr) {
       if (put_at(probe + i, tmp, nullptr)) {

--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,11 +151,10 @@ class InterpreterOopMap: ResourceObj {
 class OopMapCache : public CHeapObj<mtClass> {
  static OopMapCacheEntry* volatile _old_entries;
  private:
-  enum { _size        = 32,     // Use fixed size for now
-         _probe_depth = 3       // probe depth in case of collisions
-  };
+  static constexpr int size = 32;        // Use fixed size for now
+  static constexpr int probe_depth = 3;  // probe depth in case of collisions
 
-  OopMapCacheEntry* volatile * _array;
+  OopMapCacheEntry* volatile _array[size];
 
   unsigned int hash_value_for(const methodHandle& method, int bci) const;
   OopMapCacheEntry* entry_at(int i) const;


### PR DESCRIPTION
Clean backport to improve OopMapCache. I actually want this change in 21u-dev, so I am backporting to 23u on its way there. The change is pretty simple, so there is only a little risk.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `tier{1,2,3}`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335007](https://bugs.openjdk.org/browse/JDK-8335007) needs maintainer approval

### Issue
 * [JDK-8335007](https://bugs.openjdk.org/browse/JDK-8335007): Inline OopMapCache table (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/64.diff">https://git.openjdk.org/jdk23u/pull/64.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/64#issuecomment-2284155489)