### PR TITLE
8337971: Problem list several jvmci tests on linux-riscv64 until JDK-8331704 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -76,6 +76,12 @@ compiler/vectorapi/reshape/TestVectorReinterpret.java 8320897 aix-ppc64,linux-pp
 compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x64
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/DataPatchTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/MaxOopMapStackOffsetTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleDebugInfoTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleCodeInstallationTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java 8331704 linux-riscv64
 
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586


### PR DESCRIPTION
Hi, The same issue also exists in the jdk23u. I would like to backport [8337971](https://bugs.openjdk.org/browse/JDK-8337971) to jdk23u. With this backport, we can skip these tests on the linux-riscv64 platform. This is a risc-v specific change. Backport is clean, risk is low.

### Testing
- [x] Run hotspot:tier1 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8337971](https://bugs.openjdk.org/browse/JDK-8337971) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337971](https://bugs.openjdk.org/browse/JDK-8337971): Problem list several jvmci tests on linux-riscv64 until JDK-8331704 is fixed (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/65.diff">https://git.openjdk.org/jdk23u/pull/65.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/65#issuecomment-2285359867)