### PR TITLE
8337795: Type annotation attached to incorrect type during class reading

### DIFF
--- a/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
+++ b/test/langtools/tools/javac/processing/model/type/BasicAnnoTests.java
@@ -717,4 +717,8 @@ public class BasicAnnoTests extends JavacTestingAbstractProcessor {
             GenericNested(@TA(120) GenericInner120<X> GenericInner120.this) {}
         }
     }
+
+    @Test(posn=1, annoType=TA.class, expect="130")
+    @Test(posn=23, annoType=TA.class, expect="131")
+    public Map<@TA(130) String, @TA(131) String> f130;
 }


### PR DESCRIPTION
This change fixes a bug in javac's handling of type annotations in bytecode, which was logic first added in JDK 22 as part of the fix for JDK-8225377.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8337795](https://bugs.openjdk.org/browse/JDK-8337795) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337795](https://bugs.openjdk.org/browse/JDK-8337795): Type annotation attached to incorrect type during class reading (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/67.diff">https://git.openjdk.org/jdk23u/pull/67.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/67#issuecomment-2286758681)