### PR TITLE
8333354: ubsan: frame.inline.hpp:91:25: and src/hotspot/share/runtime/frame.inline.hpp:88:29: runtime error: member call on null pointer of type 'const struct SmallRegisterMap'

### DIFF
--- a/src/hotspot/cpu/aarch64/smallRegisterMap_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/smallRegisterMap_aarch64.inline.hpp
@@ -30,8 +30,15 @@
 
 // Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
 class SmallRegisterMap {
+  constexpr SmallRegisterMap() = default;
+  ~SmallRegisterMap() = default;
+  NONCOPYABLE(SmallRegisterMap);
+
 public:
-  static constexpr SmallRegisterMap* instance = nullptr;
+  static const SmallRegisterMap* instance() {
+    static constexpr SmallRegisterMap the_instance{};
+    return &the_instance;
+  }
 private:
   static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ assert (r == rfp->as_VMReg() || r == rfp->as_VMReg()->next(), "Reg: %s", r->name()); })
@@ -46,17 +53,6 @@ public:
     map->set_include_argument_oops(this->include_argument_oops());
     frame::update_map_with_saved_link(map, (intptr_t**)sp - frame::sender_sp_offset);
     return map;
-  }
-
-  SmallRegisterMap() {}
-
-  SmallRegisterMap(const RegisterMap* map) {
-  #ifdef ASSERT
-    for(int i = 0; i < RegisterMap::reg_count; i++) {
-      VMReg r = VMRegImpl::as_VMReg(i);
-      if (map->location(r, (intptr_t*)nullptr) != nullptr) assert_is_rfp(r);
-    }
-  #endif
   }
 
   inline address location(VMReg reg, intptr_t* sp) const {

--- a/src/hotspot/cpu/arm/smallRegisterMap_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/smallRegisterMap_arm.inline.hpp
@@ -30,8 +30,15 @@
 
 // Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
 class SmallRegisterMap {
+  constexpr SmallRegisterMap() = default;
+  ~SmallRegisterMap() = default;
+  NONCOPYABLE(SmallRegisterMap);
+
 public:
-  static constexpr SmallRegisterMap* instance = nullptr;
+  static const SmallRegisterMap* instance() {
+    static constexpr SmallRegisterMap the_instance{};
+    return &the_instance;
+  }
 private:
   static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
@@ -44,12 +51,6 @@ public:
   RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
     Unimplemented();
     return map;
-  }
-
-  SmallRegisterMap() {}
-
-  SmallRegisterMap(const RegisterMap* map) {
-    Unimplemented();
   }
 
   inline address location(VMReg reg, intptr_t* sp) const {

--- a/src/hotspot/cpu/ppc/smallRegisterMap_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/smallRegisterMap_ppc.inline.hpp
@@ -30,9 +30,16 @@
 
 // Java frames don't have callee saved registers, so we can use a smaller RegisterMap
 class SmallRegisterMap {
+  constexpr SmallRegisterMap() = default;
+  ~SmallRegisterMap() = default;
+  NONCOPYABLE(SmallRegisterMap);
+
 public:
-  static constexpr SmallRegisterMap* instance = nullptr;
-public:
+  static const SmallRegisterMap* instance() {
+    static constexpr SmallRegisterMap the_instance{};
+    return &the_instance;
+  }
+
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap
   // Consider enhancing SmallRegisterMap to support those cases
   const RegisterMap* as_RegisterMap() const { return nullptr; }
@@ -42,19 +49,6 @@ public:
     map->clear();
     map->set_include_argument_oops(this->include_argument_oops());
     return map;
-  }
-
-  SmallRegisterMap() {}
-
-  SmallRegisterMap(const RegisterMap* map) {
-#ifdef ASSERT
-  for(int i = 0; i < RegisterMap::reg_count; i++) {
-    VMReg r = VMRegImpl::as_VMReg(i);
-    if (map->location(r, (intptr_t*)nullptr) != nullptr) {
-      assert(false, "Reg: %s", r->name()); // Should not reach here
-    }
-  }
-#endif
   }
 
   inline address location(VMReg reg, intptr_t* sp) const {

--- a/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
@@ -30,8 +30,15 @@
 
 // Java frames don't have callee saved registers (except for fp), so we can use a smaller RegisterMap
 class SmallRegisterMap {
+  constexpr SmallRegisterMap() = default;
+  ~SmallRegisterMap() = default;
+  NONCOPYABLE(SmallRegisterMap);
+
 public:
-  static constexpr SmallRegisterMap* instance = nullptr;
+  static const SmallRegisterMap* instance() {
+    static constexpr SmallRegisterMap the_instance{};
+    return &the_instance;
+  }
 private:
   static void assert_is_fp(VMReg r) NOT_DEBUG_RETURN
                                     DEBUG_ONLY({ assert (r == fp->as_VMReg() || r == fp->as_VMReg()->next(), "Reg: %s", r->name()); })
@@ -46,17 +53,6 @@ public:
     map->set_include_argument_oops(this->include_argument_oops());
     frame::update_map_with_saved_link(map, (intptr_t**)sp - 2);
     return map;
-  }
-
-  SmallRegisterMap() {}
-
-  SmallRegisterMap(const RegisterMap* map) {
-  #ifdef ASSERT
-    for(int i = 0; i < RegisterMap::reg_count; i++) {
-      VMReg r = VMRegImpl::as_VMReg(i);
-      if (map->location(r, (intptr_t*)nullptr) != nullptr) assert_is_fp(r);
-    }
-  #endif
   }
 
   inline address location(VMReg reg, intptr_t* sp) const {

--- a/src/hotspot/cpu/s390/smallRegisterMap_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/smallRegisterMap_s390.inline.hpp
@@ -30,8 +30,15 @@
 
 // Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
 class SmallRegisterMap {
+  constexpr SmallRegisterMap() = default;
+  ~SmallRegisterMap() = default;
+  NONCOPYABLE(SmallRegisterMap);
+
 public:
-  static constexpr SmallRegisterMap* instance = nullptr;
+  static const SmallRegisterMap* instance() {
+    static constexpr SmallRegisterMap the_instance{};
+    return &the_instance;
+  }
 private:
   static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
@@ -44,12 +51,6 @@ public:
   RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
     Unimplemented();
     return map;
-  }
-
-  SmallRegisterMap() {}
-
-  SmallRegisterMap(const RegisterMap* map) {
-    Unimplemented();
   }
 
   inline address location(VMReg reg, intptr_t* sp) const {

--- a/src/hotspot/cpu/zero/smallRegisterMap_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/smallRegisterMap_zero.inline.hpp
@@ -30,8 +30,15 @@
 
 // Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
 class SmallRegisterMap {
+  constexpr SmallRegisterMap() = default;
+  ~SmallRegisterMap() = default;
+  NONCOPYABLE(SmallRegisterMap);
+
 public:
-  static constexpr SmallRegisterMap* instance = nullptr;
+  static const SmallRegisterMap* instance() {
+    static constexpr SmallRegisterMap the_instance{};
+    return &the_instance;
+  }
 private:
   static void assert_is_rfp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ Unimplemented(); })
@@ -44,12 +51,6 @@ public:
   RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
     Unimplemented();
     return map;
-  }
-
-  SmallRegisterMap() {}
-
-  SmallRegisterMap(const RegisterMap* map) {
-    Unimplemented();
   }
 
   inline address location(VMReg reg, intptr_t* sp) const {

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -125,7 +125,7 @@ static int num_java_frames(const StackChunkFrameStream<ChunkFrames::Mixed>& f) {
 int stackChunkOopDesc::num_java_frames() const {
   int n = 0;
   for (StackChunkFrameStream<ChunkFrames::Mixed> f(const_cast<stackChunkOopDesc*>(this)); !f.is_done();
-       f.next(SmallRegisterMap::instance)) {
+       f.next(SmallRegisterMap::instance())) {
     if (!f.is_stub()) {
       n += ::num_java_frames(f);
     }

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -201,7 +201,7 @@ inline void stackChunkOopDesc::iterate_stack(StackChunkFrameClosureType* closure
 
 template <ChunkFrames frame_kind, class StackChunkFrameClosureType>
 inline void stackChunkOopDesc::iterate_stack(StackChunkFrameClosureType* closure) {
-  const SmallRegisterMap* map = SmallRegisterMap::instance;
+  const SmallRegisterMap* map = SmallRegisterMap::instance();
   assert(!map->in_cont(), "");
 
   StackChunkFrameStream<frame_kind> f(this);

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1860,7 +1860,7 @@ int ThawBase::remove_top_compiled_frame_from_chunk(stackChunkOop chunk, int &arg
   const int frame_size = f.cb()->frame_size();
   argsize = f.stack_argsize();
 
-  f.next(SmallRegisterMap::instance, true /* stop */);
+  f.next(SmallRegisterMap::instance(), true /* stop */);
   empty = f.is_done();
   assert(!empty || argsize == chunk->argsize(), "");
 
@@ -2070,7 +2070,7 @@ bool ThawBase::recurse_thaw_java_frame(frame& caller, int num_frames) {
 
   int argsize = _stream.stack_argsize();
 
-  _stream.next(SmallRegisterMap::instance);
+  _stream.next(SmallRegisterMap::instance());
   assert(_stream.to_frame().is_empty() == _stream.is_done(), "");
 
   // we never leave a compiled caller of an interpreted frame as the top frame in the chunk
@@ -2178,7 +2178,7 @@ NOINLINE void ThawBase::recurse_thaw_interpreted_frame(const frame& hf, frame& c
   assert(hf.is_interpreted_frame(), "");
 
   if (UNLIKELY(seen_by_gc())) {
-    _cont.tail()->do_barriers<stackChunkOopDesc::BarrierType::Store>(_stream, SmallRegisterMap::instance);
+    _cont.tail()->do_barriers<stackChunkOopDesc::BarrierType::Store>(_stream, SmallRegisterMap::instance());
   }
 
   const bool is_bottom_frame = recurse_thaw_java_frame<ContinuationHelper::InterpretedFrame>(caller, num_frames);
@@ -2221,7 +2221,7 @@ NOINLINE void ThawBase::recurse_thaw_interpreted_frame(const frame& hf, frame& c
 
   if (!is_bottom_frame) {
     // can only fix caller once this frame is thawed (due to callee saved regs)
-    _cont.tail()->fix_thawed_frame(caller, SmallRegisterMap::instance);
+    _cont.tail()->fix_thawed_frame(caller, SmallRegisterMap::instance());
   } else if (_cont.tail()->has_bitmap() && locals > 0) {
     assert(hf.is_heap_frame(), "should be");
     address start = (address)(heap_frame_bottom - locals);
@@ -2238,7 +2238,7 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
   assert(_cont.is_preempted() || !stub_caller, "stub caller not at preemption");
 
   if (!stub_caller && UNLIKELY(seen_by_gc())) { // recurse_thaw_stub_frame already invoked our barriers with a full regmap
-    _cont.tail()->do_barriers<stackChunkOopDesc::BarrierType::Store>(_stream, SmallRegisterMap::instance);
+    _cont.tail()->do_barriers<stackChunkOopDesc::BarrierType::Store>(_stream, SmallRegisterMap::instance());
   }
 
   const bool is_bottom_frame = recurse_thaw_java_frame<ContinuationHelper::CompiledFrame>(caller, num_frames);
@@ -2297,7 +2297,7 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
 
   if (!is_bottom_frame) {
     // can only fix caller once this frame is thawed (due to callee saved regs); this happens on the stack
-    _cont.tail()->fix_thawed_frame(caller, SmallRegisterMap::instance);
+    _cont.tail()->fix_thawed_frame(caller, SmallRegisterMap::instance());
   } else if (_cont.tail()->has_bitmap() && added_argsize > 0) {
     address start = (address)(heap_frame_top + ContinuationHelper::CompiledFrame::size(hf) + frame::metadata_words_at_top);
     int stack_args_slots = f.cb()->as_nmethod()->num_stack_arg_slots(false /* rounded */);
@@ -2379,7 +2379,7 @@ void ThawBase::finish_thaw(frame& f) {
     f.set_sp(align_down(f.sp(), frame::frame_alignment));
   }
   push_return_frame(f);
-  chunk->fix_thawed_frame(f, SmallRegisterMap::instance); // can only fix caller after push_return_frame (due to callee saved regs)
+  chunk->fix_thawed_frame(f, SmallRegisterMap::instance()); // can only fix caller after push_return_frame (due to callee saved regs)
 
   assert(_cont.is_empty() == _cont.last_frame().is_empty(), "");
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333354](https://bugs.openjdk.org/browse/JDK-8333354) needs maintainer approval

### Issue
 * [JDK-8333354](https://bugs.openjdk.org/browse/JDK-8333354): ubsan: frame.inline.hpp:91:25: and src/hotspot/share/runtime/frame.inline.hpp:88:29: runtime error: member call on null pointer of type 'const struct SmallRegisterMap' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/71/head:pull/71` \
`$ git checkout pull/71`

Update a local copy of the PR: \
`$ git checkout pull/71` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/71/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 71`

View PR using the GUI difftool: \
`$ git pr show -t 71`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/71.diff">https://git.openjdk.org/jdk23u/pull/71.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/71#issuecomment-2288485380)