### PR TITLE
8335449: runtime/cds/DeterministicDump.java fails with File content different at byte ...

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8241071
  * @summary The same JDK build should always generate the same archive file (no randomness).
- * @requires vm.cds
+ * @requires vm.cds & vm.flagless
  * @library /test/lib
  * @run driver DeterministicDump
  */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [284671a1](https://github.com/openjdk/jdk/commit/284671a1e4fb5bfe15b20b7f41fc24415b1235ed) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Calvin Cheung on 8 Jul 2024 and was reviewed by Matias Saavedra Silva and Ioi Lam.

Clean backport to make the test more robustness, test fix only, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335449](https://bugs.openjdk.org/browse/JDK-8335449) needs maintainer approval

### Issue
 * [JDK-8335449](https://bugs.openjdk.org/browse/JDK-8335449): runtime/cds/DeterministicDump.java fails with File content different at byte ... (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/80.diff">https://git.openjdk.org/jdk23u/pull/80.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/80#issuecomment-2301250458)