### PR TITLE
8334229: Optimize InterpreterOopMap layout

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -84,18 +84,18 @@ class InterpreterOopMap: ResourceObj {
 
  private:
   Method*        _method;         // the method for which the mask is valid
-  unsigned short _bci;            // the bci    for which the mask is valid
   int            _mask_size;      // the mask size in bits (USHRT_MAX if invalid)
   int            _expression_stack_size; // the size of the expression stack in slots
+  unsigned short _bci;            // the bci    for which the mask is valid
 
  protected:
+  int            _num_oops;
   intptr_t       _bit_mask[N];    // the bit mask if
                                   // mask_size <= small_mask_limit,
                                   // ptr to bit mask otherwise
                                   // "protected" so that sub classes can
                                   // access it without using trickery in
                                   // method bit_mask().
-  int            _num_oops;
 
   // access methods
   Method*        method() const                  { return _method; }


### PR DESCRIPTION
Semi-clean backport to improve OopMapCache. I actually want this change in 21u-dev, so I am backporting to 23u on its way there. The change is pretty simple, so there is only a little risk.

It is different from mainline change, because [JDK-8335409](https://bugs.openjdk.org/browse/JDK-8335409) went into 23u first. It removes one of the definitions we move: https://github.com/openjdk/jdk/commit/7ab96c74e2c39f430a5c2f65a981da7314a2385b#diff-d47427bcae3d32d55540df020532bf223ed3cdc6496c3277068e0125fa7be22cL91-L93

Applying this backport yields no difference in `oopMapCache.hpp` with mainline version, which is what we want.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334229](https://bugs.openjdk.org/browse/JDK-8334229) needs maintainer approval

### Issue
 * [JDK-8334229](https://bugs.openjdk.org/browse/JDK-8334229): Optimize InterpreterOopMap layout (**Sub-task** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/81.diff">https://git.openjdk.org/jdk23u/pull/81.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/81#issuecomment-2302611449)