### PR TITLE
8335172: Add manual steps to run security/auth/callback/TextCallbackHandler/Password.java test

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -610,7 +610,6 @@ sun/security/smartcardio/TestPresent.java                       8039280 generic-
 sun/security/smartcardio/TestTransmit.java                      8039280 generic-all
 com/sun/crypto/provider/Cipher/DES/PerformanceTest.java         8039280 generic-all
 com/sun/security/auth/callback/TextCallbackHandler/Default.java 8039280 generic-all
-com/sun/security/auth/callback/TextCallbackHandler/Password.java 8039280 generic-all
 com/sun/security/sasl/gsskerb/AuthOnly.java                     8039280 generic-all
 com/sun/security/sasl/gsskerb/ConfSecurityLayer.java            8039280 generic-all
 com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-all

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -625,7 +625,6 @@ jdk_security_manual_no_input = \
     com/sun/crypto/provider/Cipher/AEAD/GCMIncrementByte4.java \
     com/sun/crypto/provider/Cipher/AEAD/GCMIncrementDirect4.java \
     com/sun/security/auth/callback/TextCallbackHandler/Default.java \
-    com/sun/security/auth/callback/TextCallbackHandler/Password.java \
     com/sun/security/sasl/gsskerb/AuthOnly.java \
     com/sun/security/sasl/gsskerb/ConfSecurityLayer.java \
     com/sun/security/sasl/gsskerb/NoSecurityLayer.java \
@@ -654,6 +653,7 @@ jdk_core_manual_interactive = \
 jdk_security_manual_interactive = \
     sun/security/tools/keytool/i18n.java \
     java/security/Policy/Root/Root.java \
+    com/sun/security/auth/callback/TextCallbackHandler/Password.java \
     sun/security/krb5/config/native/TestDynamicStore.java
 
 # Test sets for running inside container environment

--- a/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
+++ b/test/jdk/com/sun/security/auth/callback/TextCallbackHandler/Password.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,21 @@
 
 /*
  * @test
- * @bug 6825240
+ * @bug 6825240 6829785
  * @summary Password.readPassword() echos the input when System.Console is null
  * @run main/manual Password
+ */
+
+/*
+ * This scenario cannot be automated because util/Password.java verifies the given input stream is
+ * equal to the initialSystemIn. This prevents the test from providing a custom input stream.
+ *
+ *  Steps to run the test:
+ *  1) Compile the class using the JDK version being tested: '<JdkBin>/javac Password.java'
+ *  2) Run the test using the JDK version being tested: '<JdkBin>/java -cp . Password'
+ *  3) Type in the first password, it should not be visible in the console
+ *  4) Type in the second password, it should be visible in the console
+ *  5) The final output line displays the entered passwords, both should be visible
  */
 
 import com.sun.security.auth.callback.TextCallbackHandler;


### PR DESCRIPTION
This is a manual test. Here are the run results:-

/Users/dk-23.0.1.jdk/Contents/Home/bin/java -cp . Password 
Two passwords will be prompted for. The first one should have echo off, the second one on. Otherwise, this test fails
Invisible: 
Visible: hello
You input hello and hello

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335172](https://bugs.openjdk.org/browse/JDK-8335172) needs maintainer approval

### Issue
 * [JDK-8335172](https://bugs.openjdk.org/browse/JDK-8335172): Add manual steps to run security/auth/callback/TextCallbackHandler/Password.java test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/82.diff">https://git.openjdk.org/jdk23u/pull/82.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/82#issuecomment-2305083850)