### PR TITLE
8339384: Unintentional IOException in jdk.jdi module when JDWP end of stream occurs

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/TargetVM.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/TargetVM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,8 +123,9 @@ public class TargetVM implements Runnable {
                 byte b[] = connection.readPacket();
                 if (b.length == 0) {
                     done = true;
+                } else {
+                    p = Packet.fromByteArray(b);
                 }
-                p = Packet.fromByteArray(b);
             } catch (IOException e) {
                 done = true;
             }


### PR DESCRIPTION
Backport of [JDK-8339384](https://bugs.openjdk.org/browse/JDK-8339384)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339384](https://bugs.openjdk.org/browse/JDK-8339384) needs maintainer approval

### Issue
 * [JDK-8339384](https://bugs.openjdk.org/browse/JDK-8339384): Unintentional IOException in jdk.jdi module when JDWP end of stream occurs (**Bug** - P5 - Approved)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/99.diff">https://git.openjdk.org/jdk23u/pull/99.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/99#issuecomment-2355519356)