### PR TITLE
8340210: Add positionTestUI() to PassFailJFrame.Builder

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1251,6 +1251,29 @@ public final class PassFailJFrame {
         }
 
         /**
+         * Adds an implementation of {@link PositionWindows PositionWindows}
+         * which the framework will use to position multiple test UI windows.
+         *
+         * @param positionWindows an implementation of {@code PositionWindows}
+         *                        to position multiple test UI windows
+         * @return this builder
+         * @throws IllegalArgumentException if the {@code positionWindows}
+         *              parameter is {@code null}
+         * @throws IllegalStateException if the {@code positionWindows} field
+         *              is already set
+         */
+        public Builder positionTestUI(PositionWindows positionWindows) {
+            if (positionWindows == null) {
+                throw new IllegalArgumentException("positionWindows parameter can't be null");
+            }
+            if (this.positionWindows != null) {
+                throw new IllegalStateException("PositionWindows is already set");
+            }
+            this.positionWindows = positionWindows;
+            return this;
+        }
+
+        /**
          * Adds a {@code WindowListCreator} which the framework will use
          * to create a list of test UI windows.
          *


### PR DESCRIPTION
Backporting [JDK-8340210](https://bugs.openjdk.org/browse/JDK-8340210) to 23u.

> This pull request contains a backport of commit [f0ae90f3](https://github.com/openjdk/jdk/commit/f0ae90f30c346544e87217ef1832d6a350fe1985) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
>
> The commit being backported was authored by Harshitha Onkar on 17 Sep 2024 and was reviewed by Alexey Ivanov and Alexander Zvegintsev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8340210](https://bugs.openjdk.org/browse/JDK-8340210) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340210](https://bugs.openjdk.org/browse/JDK-8340210): Add positionTestUI() to PassFailJFrame.Builder (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/106.diff">https://git.openjdk.org/jdk23u/pull/106.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/106#issuecomment-2360730827)