### PR TITLE
Backport b639661e797fb52ce32ce397a153c886fdc40f53

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -614,10 +614,9 @@ be accepted by <code>configure</code>.</p>
 <code>--with-toolchain-type=clang</code>.</p>
 <h3 id="apple-xcode">Apple Xcode</h3>
 <p>The oldest supported version of Xcode is 13.0.</p>
-<p>You will need the Xcode command line developer tools to be able to
-build the JDK. (Actually, <em>only</em> the command line tools are
-needed, not the IDE.) The simplest way to install these is to run:</p>
-<pre><code>xcode-select --install</code></pre>
+<p>You will need to download Xcode either from the App Store or specific
+versions can be easily located via the <a
+href="https://xcodereleases.com">Xcode Releases</a> website.</p>
 <p>When updating Xcode, it is advisable to keep an older version for
 building the JDK. To use a specific version of Xcode you have multiple
 options:</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -422,13 +422,9 @@ To use clang instead of gcc on Linux, use `--with-toolchain-type=clang`.
 
 The oldest supported version of Xcode is 13.0.
 
-You will need the Xcode command line developer tools to be able to build the
-JDK. (Actually, *only* the command line tools are needed, not the IDE.) The
-simplest way to install these is to run:
-
-```
-xcode-select --install
-```
+You will need to download Xcode either from the App Store or specific versions
+can be easily located via the [Xcode Releases](https://xcodereleases.com)
+website.
 
 When updating Xcode, it is advisable to keep an older version for building the
 JDK. To use a specific version of Xcode you have multiple options:


### PR DESCRIPTION
Since JDK17 there has been a dependency on metal in the macOS builds which is only available as part of the full Xcode IDE (rather than command-line tools). We currently recommend only installing the command-line tools in the building.md doc which is incorrect.