### PR TITLE
8340657: [PPC64] SA determines wrong unextendedSP

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ppc64/PPC64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ppc64/PPC64Frame.java
@@ -317,8 +317,9 @@ public class PPC64Frame extends Frame {
   //------------------------------------------------------------------------------
   // frame::adjust_unextended_sp
   private void adjustUnextendedSP() {
-    raw_unextendedSP = getFP();
+    // Nothing to do. senderForInterpreterFrame finds the correct unextendedSP.
   }
+
   private Frame senderForInterpreterFrame(PPC64RegisterMap map) {
     if (DEBUG) {
       System.out.println("senderForInterpreterFrame");


### PR DESCRIPTION
Clean backport of [JDK-8340657](https://bugs.openjdk.org/browse/JDK-8340657).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340657](https://bugs.openjdk.org/browse/JDK-8340657) needs maintainer approval

### Issue
 * [JDK-8340657](https://bugs.openjdk.org/browse/JDK-8340657): [PPC64] SA determines wrong unextendedSP (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/125.diff">https://git.openjdk.org/jdk23u/pull/125.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/125#issuecomment-2376461916)