### PR TITLE
8334147: Shenandoah: Avoid taking lock for disabled free set logging

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -153,10 +153,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // the space. This would be the last action if there is nothing to evacuate.
   entry_cleanup_early();
 
-  {
-    ShenandoahHeapLocker locker(heap->lock());
-    heap->free_set()->log_status();
-  }
+  heap->free_set()->log_status_under_lock();
 
   // Perform concurrent class unloading
   if (heap->unload_classes() &&

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -147,10 +147,7 @@ void ShenandoahControlThread::run_service() {
       heap->set_forced_counters_update(true);
 
       // If GC was requested, we better dump freeset data for performance debugging
-      {
-        ShenandoahHeapLocker locker(heap->lock());
-        heap->free_set()->log_status();
-      }
+      heap->free_set()->log_status_under_lock();
 
       switch (mode) {
         case concurrent_normal:
@@ -178,18 +175,15 @@ void ShenandoahControlThread::run_service() {
 
       // Report current free set state at the end of cycle, whether
       // it is a normal completion, or the abort.
-      {
-        ShenandoahHeapLocker locker(heap->lock());
-        heap->free_set()->log_status();
+      heap->free_set()->log_status_under_lock();
 
-        // Notify Universe about new heap usage. This has implications for
-        // global soft refs policy, and we better report it every time heap
-        // usage goes down.
-        heap->update_capacity_and_used_at_gc();
+      // Notify Universe about new heap usage. This has implications for
+      // global soft refs policy, and we better report it every time heap
+      // usage goes down.
+      heap->update_capacity_and_used_at_gc();
 
-        // Signal that we have completed a visit to all live objects.
-        heap->record_whole_heap_examined_timestamp();
-      }
+      // Signal that we have completed a visit to all live objects.
+      heap->record_whole_heap_examined_timestamp();
 
       // Disable forced counters update, and update counters one more time
       // to capture the state at the end of GC session.

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -177,10 +177,13 @@ void ShenandoahControlThread::run_service() {
       // it is a normal completion, or the abort.
       heap->free_set()->log_status_under_lock();
 
-      // Notify Universe about new heap usage. This has implications for
-      // global soft refs policy, and we better report it every time heap
-      // usage goes down.
-      heap->update_capacity_and_used_at_gc();
+      {
+        // Notify Universe about new heap usage. This has implications for
+        // global soft refs policy, and we better report it every time heap
+        // usage goes down.
+        ShenandoahHeapLocker locker(heap->lock());
+        heap->update_capacity_and_used_at_gc();
+      }
 
       // Signal that we have completed a visit to all live objects.
       heap->record_whole_heap_examined_timestamp();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -1130,6 +1130,16 @@ void ShenandoahFreeSet::reserve_regions(size_t to_reserve) {
   }
 }
 
+void ShenandoahFreeSet::log_status_under_lock() {
+  // Must not be heap locked, it acquires heap lock only when log is enabled
+  shenandoah_assert_not_heaplocked();
+  if (LogTarget(Info, gc, free)::is_enabled()
+      DEBUG_ONLY(|| LogTarget(Debug, gc, free)::is_enabled())) {
+    ShenandoahHeapLocker locker(_heap->lock());
+    log_status();
+  }
+}
+
 void ShenandoahFreeSet::log_status() {
   shenandoah_assert_heaplocked();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -318,6 +318,9 @@ private:
 
   void finish_rebuild(size_t cset_regions);
 
+  // log status, assuming lock has already been acquired by the caller.
+  void log_status();
+
 public:
   ShenandoahFreeSet(ShenandoahHeap* heap, size_t max_regions);
 
@@ -340,7 +343,8 @@ public:
   void move_regions_from_collector_to_mutator(size_t cset_regions);
 
   void recycle_trash();
-  void log_status();
+  // Acquire heap lock and log status, assuming heap lock is not acquired by the caller.
+  void log_status_under_lock();
 
   inline size_t capacity()  const { return _partitions.capacity_of(ShenandoahFreeSetPartitionId::Mutator); }
   inline size_t used()      const { return _partitions.used_by(ShenandoahFreeSetPartitionId::Mutator);     }


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341554](https://bugs.openjdk.org/browse/JDK-8341554) needs maintainer approval
- [x] [JDK-8334147](https://bugs.openjdk.org/browse/JDK-8334147) needs maintainer approval

### Issues
 * [JDK-8334147](https://bugs.openjdk.org/browse/JDK-8334147): Shenandoah: Avoid taking lock for disabled free set logging (**Enhancement** - P4 - Approved)
 * [JDK-8341554](https://bugs.openjdk.org/browse/JDK-8341554): Shenandoah: Missing heap lock when updating usage for soft ref policy (**Bug** - P4 - Approved)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/129.diff">https://git.openjdk.org/jdk23u/pull/129.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/129#issuecomment-2387248560)