### PR TITLE
8332697: ubsan: shenandoahSimpleBitMap.inline.hpp:68:23: runtime error: signed integer overflow: -9223372036854775808 - 1 cannot be represented in type 'long int'

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
@@ -80,6 +80,8 @@ private:
   bool is_forward_consecutive_ones(idx_t start_idx, idx_t count) const;
   bool is_backward_consecutive_ones(idx_t last_idx, idx_t count) const;
 
+  static inline uintx tail_mask(uintx bit_number);
+
 public:
 
   inline idx_t aligned_index(idx_t idx) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
@@ -50,7 +50,7 @@ typedef ssize_t idx_t;
 // ShenandoahSimpleBitMap resembles CHeapBitMap but adds missing support for find_first_consecutive_set_bits() and
 // find_last_consecutive_set_bits.  An alternative refactoring of code would subclass CHeapBitMap, but this might
 // break abstraction rules, because efficient implementation requires assumptions about superclass internals that
-// might be violatee through future software maintenance.
+// might be violated through future software maintenance.
 class ShenandoahSimpleBitMap {
   const idx_t _num_bits;
   const size_t _num_words;
@@ -84,7 +84,7 @@ public:
 
   inline idx_t aligned_index(idx_t idx) const {
     assert((idx >= 0) && (idx < _num_bits), "precondition");
-    idx_t array_idx = idx & ~right_n_bits(LogBitsPerWord);
+    idx_t array_idx = idx & ~(BitsPerWord - 1);
     return array_idx;
   }
 
@@ -107,7 +107,7 @@ public:
   inline void set_bit(idx_t idx) {
     assert((idx >= 0) && (idx < _num_bits), "precondition");
     size_t array_idx = idx >> LogBitsPerWord;
-    uintx bit_number = idx & right_n_bits(LogBitsPerWord);
+    uintx bit_number = idx & (BitsPerWord - 1);
     uintx the_bit = nth_bit(bit_number);
     _bitmap[array_idx] |= the_bit;
   }
@@ -116,7 +116,7 @@ public:
     assert((idx >= 0) && (idx < _num_bits), "precondition");
     assert(idx >= 0, "precondition");
     size_t array_idx = idx >> LogBitsPerWord;
-    uintx bit_number = idx & right_n_bits(LogBitsPerWord);
+    uintx bit_number = idx & (BitsPerWord - 1);
     uintx the_bit = nth_bit(bit_number);
     _bitmap[array_idx] &= ~the_bit;
   }
@@ -125,9 +125,9 @@ public:
     assert((idx >= 0) && (idx < _num_bits), "precondition");
     assert(idx >= 0, "precondition");
     size_t array_idx = idx >> LogBitsPerWord;
-    uintx bit_number = idx & right_n_bits(LogBitsPerWord);
+    uintx bit_number = idx & (BitsPerWord - 1);
     uintx the_bit = nth_bit(bit_number);
-    return (_bitmap[array_idx] & the_bit)? true: false;
+    return (_bitmap[array_idx] & the_bit) != 0;
   }
 
   // Return the index of the first set bit in the range [beg, size()), or size() if none found.

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
@@ -27,15 +27,22 @@
 
 #include "gc/shenandoah/shenandoahSimpleBitMap.hpp"
 
+inline uintx tail_mask(uintx bit_number) {
+  if (bit_number >= BitsPerWord) {
+    return -1;
+  }
+  return (uintx(1) << bit_number) - 1;
+}
+
 inline idx_t ShenandoahSimpleBitMap::find_first_set_bit(idx_t beg, idx_t end) const {
   assert((beg >= 0) && (beg < _num_bits), "precondition");
   assert((end > beg) && (end <= _num_bits), "precondition");
   do {
     size_t array_idx = beg >> LogBitsPerWord;
-    uintx bit_number = beg & right_n_bits(LogBitsPerWord);
+    uintx bit_number = beg & (BitsPerWord - 1);
     uintx element_bits = _bitmap[array_idx];
     if (bit_number > 0) {
-      uintx mask_out = right_n_bits(bit_number);
+      uintx mask_out = tail_mask(bit_number);
       element_bits &= ~mask_out;
     }
     if (element_bits) {
@@ -62,10 +69,10 @@ inline idx_t ShenandoahSimpleBitMap::find_last_set_bit(idx_t beg, idx_t end) con
   assert((beg >= -1) && (beg < end), "precondition");
   do {
     idx_t array_idx = end >> LogBitsPerWord;
-    uintx bit_number = end & right_n_bits(LogBitsPerWord);
+    uint8_t bit_number = end & (BitsPerWord - 1);
     uintx element_bits = _bitmap[array_idx];
     if (bit_number < BitsPerWord - 1){
-      uintx mask_in = right_n_bits(bit_number + 1);
+      uintx mask_in = tail_mask(bit_number + 1);
       element_bits &= mask_in;
     }
     if (element_bits) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
@@ -27,7 +27,7 @@
 
 #include "gc/shenandoah/shenandoahSimpleBitMap.hpp"
 
-inline uintx tail_mask(uintx bit_number) {
+inline uintx ShenandoahSimpleBitMap::tail_mask(uintx bit_number) {
   if (bit_number >= BitsPerWord) {
     return -1;
   }


### PR DESCRIPTION
Clean backport. Fixes ubsan error in Shenandoah.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332697](https://bugs.openjdk.org/browse/JDK-8332697) needs maintainer approval
- [x] [JDK-8341668](https://bugs.openjdk.org/browse/JDK-8341668) needs maintainer approval

### Issues
 * [JDK-8332697](https://bugs.openjdk.org/browse/JDK-8332697): ubsan: shenandoahSimpleBitMap.inline.hpp:68:23: runtime error: signed integer overflow: -9223372036854775808 - 1 cannot be represented in type 'long int' (**Bug** - P4 - Approved)
 * [JDK-8341668](https://bugs.openjdk.org/browse/JDK-8341668): Shenandoah: assert(tail_bits &lt; (idx_t)BitsPerWord) failed: precondition (**Bug** - P4 - Approved)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/135/head:pull/135` \
`$ git checkout pull/135`

Update a local copy of the PR: \
`$ git checkout pull/135` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 135`

View PR using the GUI difftool: \
`$ git pr show -t 135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/135.diff">https://git.openjdk.org/jdk23u/pull/135.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/135#issuecomment-2394293513)