### PR TITLE
8340398: [JVMCI] Unintuitive behavior of UseJVMCICompiler option

### DIFF
--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -80,6 +80,15 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   CHECK_NOT_SET(LibJVMCICompilerThreadHidden, UseJVMCICompiler)
 
   if (UseJVMCICompiler) {
+    if (!FLAG_IS_DEFAULT(EnableJVMCI) && !EnableJVMCI) {
+      jio_fprintf(defaultStream::error_stream(),
+          "Improperly specified VM option UseJVMCICompiler: EnableJVMCI cannot be disabled\n");
+      return false;
+    }
+    FLAG_SET_DEFAULT(EnableJVMCI, true);
+  }
+
+  if (EnableJVMCI) {
     if (FLAG_IS_DEFAULT(UseJVMCINativeLibrary) && !UseJVMCINativeLibrary) {
       char path[JVM_MAXPATHLEN];
       if (os::dll_locate_lib(path, sizeof(path), Arguments::get_dll_dir(), JVMCI_SHARED_LIBRARY_NAME)) {
@@ -88,12 +97,9 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
         FLAG_SET_DEFAULT(UseJVMCINativeLibrary, true);
       }
     }
-    if (!FLAG_IS_DEFAULT(EnableJVMCI) && !EnableJVMCI) {
-      jio_fprintf(defaultStream::error_stream(),
-          "Improperly specified VM option UseJVMCICompiler: EnableJVMCI cannot be disabled\n");
-      return false;
-    }
-    FLAG_SET_DEFAULT(EnableJVMCI, true);
+  }
+
+  if (UseJVMCICompiler) {
     if (BootstrapJVMCI && UseJVMCINativeLibrary) {
       jio_fprintf(defaultStream::error_stream(), "-XX:+BootstrapJVMCI is not compatible with -XX:+UseJVMCINativeLibrary\n");
       return false;

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -140,7 +140,7 @@ class fileStream;
   product(bool, UseJVMCINativeLibrary, false, EXPERIMENTAL,                 \
           "Execute JVMCI Java code from a shared library (\"libjvmci\") "   \
           "instead of loading it from class files and executing it "        \
-          "on the HotSpot heap. Defaults to true if EnableJVMCIProduct is " \
+          "on the HotSpot heap. Defaults to true if EnableJVMCI is "        \
           "true and a JVMCI native library is available.")                  \
                                                                             \
   product(double, JVMCINativeLibraryThreadFraction, 0.33, EXPERIMENTAL,     \

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
@@ -104,12 +104,15 @@ final class HotSpotJVMCICompilerConfig {
                         }
                     }
                     if (factory == null) {
+                        String reason;
                         if (Services.IS_IN_NATIVE_IMAGE) {
-                            throw runtime.exitHotSpotWithMessage(1, "JVMCI compiler '%s' not found in JVMCI native library.%n" +
+                            reason = String.format("JVMCI compiler '%s' not found in JVMCI native library.%n" +
                                             "Use -XX:-UseJVMCINativeLibrary when specifying a JVMCI compiler available on a class path with %s.%n",
                                             compilerName, compPropertyName);
+                        } else {
+                            reason = String.format("JVMCI compiler '%s' specified by %s not found%n", compilerName, compPropertyName);
                         }
-                        throw runtime.exitHotSpotWithMessage(1, "JVMCI compiler '%s' specified by %s not found%n", compilerName, compPropertyName);
+                        factory = new DummyCompilerFactory(reason, runtime);
                     }
                 }
             } else {


### PR DESCRIPTION
Clean backport of patch authored by @tzezula and approved by @dougxc

The patch default-enables `useJVMCINativeLibrary` when `EnableJVMCI` is on and `libgraal` present. While this is a behavior change, it seems unlikely that users would deploy `libgraal` and _not_ want it used by JVMCI.

This streamlines configuration of our JDK+Graal distro, which in turn allows two failing tests to pass without modification. Ultimately I'm aiming to get this into jdk21 which is our upstream: https://github.com/openjdk/jdk21u-dev/pull/1024

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340398](https://bugs.openjdk.org/browse/JDK-8340398) needs maintainer approval

### Issue
 * [JDK-8340398](https://bugs.openjdk.org/browse/JDK-8340398): [JVMCI] Unintuitive behavior of UseJVMCICompiler option (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/136/head:pull/136` \
`$ git checkout pull/136`

Update a local copy of the PR: \
`$ git checkout pull/136` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 136`

View PR using the GUI difftool: \
`$ git pr show -t 136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/136.diff">https://git.openjdk.org/jdk23u/pull/136.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/136#issuecomment-2397367036)