### PR TITLE
8341261: Tests assume UnlockExperimentalVMOptions is disabled by default

### DIFF
--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires ! vm.opt.final.UnlockExperimentalVMOptions
  * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeExperimentalUnlockTest
  */

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
@@ -22,14 +22,37 @@
  */
 
 /*
- * @test
+ * @test VMOptionWarningExperimental
  * @bug 8027314
- * @summary Warn if diagnostic or experimental vm option is used and -XX:+UnlockDiagnosticVMOptions or -XX:+UnlockExperimentalVMOptions, respectively, isn't specified. Warn if develop vm option is used with product version of VM.
+ * @summary Warn if experimental vm option is used and -XX:+UnlockExperimentalVMOptions isn't specified.
  * @requires vm.flagless
+ * @requires ! vm.opt.final.UnlockExperimentalVMOptions
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver VMOptionWarning
+ * @run driver VMOptionWarning Experimental
+ */
+
+/* @test VMOptionWarningDiagnostic
+ * @bug 8027314
+ * @summary Warn if diagnostic vm option is used and -XX:+UnlockDiagnosticVMOptions isn't specified.
+ * @requires vm.flagless
+ * @requires ! vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver VMOptionWarning Diagnostic
+ */
+
+/* @test VMOptionWarningDevelop
+ * @bug 8027314
+ * @summary Warn if develop vm option is used with product version of VM.
+ * @requires vm.flagless
+ * @requires ! vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver VMOptionWarning Develop
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -38,24 +61,37 @@ import jdk.test.lib.Platform;
 
 public class VMOptionWarning {
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+AlwaysSafeConstructors", "-version");
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldNotHaveExitValue(0);
-        output.shouldContain("Error: VM option 'AlwaysSafeConstructors' is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions.");
-
-        if (Platform.isDebugBuild()) {
-            System.out.println("Skip the rest of the tests on debug builds since diagnostic, and develop options are available on debug builds.");
-            return;
+        if (args.length != 1) {
+            throw new RuntimeException("wrong number of args: " + args.length);
         }
 
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+PrintInlining", "-version");
-        output = new OutputAnalyzer(pb.start());
-        output.shouldNotHaveExitValue(0);
-        output.shouldContain("Error: VM option 'PrintInlining' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
-
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+VerifyStack", "-version");
-        output = new OutputAnalyzer(pb.start());
-        output.shouldNotHaveExitValue(0);
-        output.shouldContain("Error: VM option 'VerifyStack' is develop and is available only in debug version of VM.");
+        ProcessBuilder pb;
+        OutputAnalyzer output;
+        switch (args[0]) {
+            case "Experimental": {
+                pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+AlwaysSafeConstructors", "-version");
+                output = new OutputAnalyzer(pb.start());
+                output.shouldNotHaveExitValue(0);
+                output.shouldContain("Error: VM option 'AlwaysSafeConstructors' is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions.");
+                break;
+            }
+            case "Diagnostic": {
+                pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+PrintInlining", "-version");
+                output = new OutputAnalyzer(pb.start());
+                output.shouldNotHaveExitValue(0);
+                output.shouldContain("Error: VM option 'PrintInlining' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
+                break;
+            }
+            case "Develop": {
+                pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+VerifyStack", "-version");
+                output = new OutputAnalyzer(pb.start());
+                output.shouldNotHaveExitValue(0);
+                output.shouldContain("Error: VM option 'VerifyStack' is develop and is available only in debug version of VM.");
+                break;
+            }
+            default: {
+                throw new RuntimeException("Invalid argument: " + args[0]);
+            }
+        }
     }
 }

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -384,6 +384,7 @@ public class VMProps implements Callable<Map<String, String>> {
         vmOptFinalFlag(map, "CriticalJNINatives");
         vmOptFinalFlag(map, "EnableJVMCI");
         vmOptFinalFlag(map, "EliminateAllocations");
+        vmOptFinalFlag(map, "UnlockExperimentalVMOptions");
         vmOptFinalFlag(map, "UseCompressedOops");
         vmOptFinalFlag(map, "UseVectorizedMismatchIntrinsic");
         vmOptFinalFlag(map, "UseVtableBasedCHA");


### PR DESCRIPTION
Clean backport of test changes that ease Graal integration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8341261](https://bugs.openjdk.org/browse/JDK-8341261) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341261](https://bugs.openjdk.org/browse/JDK-8341261): Tests assume UnlockExperimentalVMOptions is disabled by default (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/137.diff">https://git.openjdk.org/jdk23u/pull/137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/137#issuecomment-2397365170)