### PR TITLE
8332461: ubsan : dependencies.cpp:906:3: runtime error: load of value 4294967295, which is not a valid value for type 'DepType'

### DIFF
--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -897,7 +897,7 @@ void Dependencies::DepStream::print_dependency(outputStream* st, Klass* witness,
 void Dependencies::DepStream::initial_asserts(size_t byte_limit) {
   assert(must_be_in_vm(), "raw oops here");
   _byte_limit = byte_limit;
-  _type       = (DepType)(end_marker-1);  // defeat "already at end" assert
+  _type       = undefined_dependency;  // defeat "already at end" assert
   assert((_code!=nullptr) + (_deps!=nullptr) == 1, "one or t'other");
 }
 #endif //ASSERT

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,6 +103,9 @@ class Dependencies: public ResourceObj {
   // type now includes N, that is, all super types of N.
   //
   enum DepType {
+    // _type is initially set to -1, to prevent "already at end" assert
+    undefined_dependency = -1,
+
     end_marker = 0,
 
     // An 'evol' dependency simply notes that the contents of the


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [28de44da](https://github.com/openjdk/jdk/commit/28de44da71871bec7648f01a4df2faee43fa43b6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Amit Kumar on 5 Sep 2024 and was reviewed by Stefan Karlsson, Vladimir Kozlov and Dean Long.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332461](https://bugs.openjdk.org/browse/JDK-8332461) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332461: ubsan : dependencies.cpp:906:3: runtime error: load of value 4294967295, which is not a valid value for type 'DepType'`

### Issue
 * [JDK-8332461](https://bugs.openjdk.org/browse/JDK-8332461): ubsan : dependencies.cpp:906:3: runtime error: load of value 4294967295, which is not a valid value for type 'DepType' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/138.diff">https://git.openjdk.org/jdk23u/pull/138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/138#issuecomment-2395943538)