### PR TITLE
8339386: Assertion on AIX - original PC must be in the main code section of the compiled method

### DIFF
--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -117,9 +117,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
-    common_abi* sender_abi = (common_abi*) fp;
+    volatile common_abi* sender_abi = (common_abi*) fp; // May get updated concurrently by deoptimization!
     intptr_t* sender_sp = (intptr_t*) fp;
-    address   sender_pc = (address) sender_abi->lr;;
+    address   sender_pc = (address) sender_abi->lr;
 
     if (Continuation::is_return_barrier_entry(sender_pc)) {
       // If our sender_pc is the return barrier, then our "real" sender is the continuation entry
@@ -134,9 +134,18 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
+    intptr_t* unextended_sender_sp = is_interpreted_frame() ? interpreter_frame_sender_sp() : sender_sp;
+
+    // If the sender is a deoptimized nmethod we need to check if the original pc is valid.
+    nmethod* sender_nm = sender_blob->as_nmethod_or_null();
+    if (sender_nm != nullptr && sender_nm->is_deopt_pc(sender_pc)) {
+      address orig_pc = *(address*)((address)unextended_sender_sp + sender_nm->orig_pc_offset());
+      if (!sender_nm->insts_contains_inclusive(orig_pc)) return false;
+    }
+
     // It should be safe to construct the sender though it might not be valid.
 
-    frame sender(sender_sp, sender_pc, nullptr /* unextended_sp */, nullptr /* fp */, sender_blob);
+    frame sender(sender_sp, sender_pc, unextended_sender_sp, nullptr /* fp */, sender_blob);
 
     // Do we have a valid fp?
     address sender_fp = (address) sender.fp();


### PR DESCRIPTION
Clean backport of [JDK-8339386](https://bugs.openjdk.org/browse/JDK-8339386).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8339386](https://bugs.openjdk.org/browse/JDK-8339386) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339386](https://bugs.openjdk.org/browse/JDK-8339386): Assertion on AIX - original PC must be in the main code section of the compiled method (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/140/head:pull/140` \
`$ git checkout pull/140`

Update a local copy of the PR: \
`$ git checkout pull/140` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 140`

View PR using the GUI difftool: \
`$ git pr show -t 140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/140.diff">https://git.openjdk.org/jdk23u/pull/140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/140#issuecomment-2396616228)