### PR TITLE
Backport 88801caef6ccdc5ba9ade2af830f3b3cd96e1467

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -4801,11 +4801,10 @@ instruct gather_loadS(vReg dst, indirect mem, vReg idx) %{
   effect(TEMP_DEF dst);
   format %{ "gather_loadS $dst, $mem, $idx" %}
   ins_encode %{
-    __ vmv1r_v(as_VectorRegister($dst$$reg), as_VectorRegister($idx$$reg));
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), (int)sew);
+    __ vsll_vi(as_VectorRegister($dst$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vluxei32_v(as_VectorRegister($dst$$reg), as_Register($mem$$base),
                   as_VectorRegister($dst$$reg));
  %}
@@ -4835,11 +4834,10 @@ instruct gather_loadS_masked(vReg dst, indirect mem, vReg idx, vRegMask_V0 v0, v
   effect(TEMP_DEF dst, TEMP tmp);
   format %{ "gather_loadS_masked $dst, $mem, $idx, $v0\t# KILL $tmp" %}
   ins_encode %{
-    __ vmv1r_v(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
     BasicType bt = Matcher::vector_element_basic_type(this);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
+    __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vxor_vv(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg),
                as_VectorRegister($dst$$reg));
     __ vluxei32_v(as_VectorRegister($dst$$reg), as_Register($mem$$base),
@@ -4875,11 +4873,10 @@ instruct scatter_storeS(indirect mem, vReg src, vReg idx, vReg tmp) %{
   effect(TEMP tmp);
   format %{ "scatter_storeS $mem, $idx, $src\t# KILL $tmp" %}
   ins_encode %{
-    __ vmv1r_v(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
-    __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
+    __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vsuxei32_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
                   as_VectorRegister($tmp$$reg));
   %}
@@ -4909,11 +4906,10 @@ instruct scatter_storeS_masked(indirect mem, vReg src, vReg idx, vRegMask_V0 v0,
   effect(TEMP tmp);
   format %{ "scatter_storeS_masked $mem, $idx, $src, $v0\t# KILL $tmp" %}
   ins_encode %{
-    __ vmv1r_v(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg));
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     __ vsetvli_helper(bt, Matcher::vector_length(this, $src));
-    __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($tmp$$reg), (int)sew);
+    __ vsll_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($idx$$reg), (int)sew);
     __ vsuxei32_v(as_VectorRegister($src$$reg), as_Register($mem$$base),
                   as_VectorRegister($tmp$$reg), Assembler::v0_t);
   %}


### PR DESCRIPTION
Hi, The same issue also exists in the jdk23u. I would like to backport 8340590 to jdk23u. This is a risc-v specific change. Backport is clean, risk is low.

### Testing
- [ ] make test TEST="jdk_vector" JTREG="TIMEOUT_FACTOR=32" on qemu with UseRVV1.0