### PR TITLE
8340461: Amend description for logArea

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -159,7 +159,7 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  *     <li>the title of the instruction UI,</li>
  *     <li>the timeout of the test,</li>
  *     <li>the size of the instruction UI via rows and columns, and</li>
- *     <li>to add a log area</li>,
+ *     <li>to add a log area,</li>
  *     <li>to enable screenshots.</li>
  * </ul>
  */
@@ -1113,9 +1113,10 @@ public final class PassFailJFrame {
 
     /**
      * Adds a {@code message} to the log area, if enabled by
-     * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
+     * {@link Builder#logArea() logArea()} or
+     * {@link Builder#logArea(int) logArea(int)}.
      *
-     * @param message to log
+     * @param message the message to log
      */
     public static void log(String message) {
         System.out.println("PassFailJFrame: " + message);
@@ -1124,7 +1125,8 @@ public final class PassFailJFrame {
 
     /**
      * Clears the log area, if enabled by
-     * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
+     * {@link Builder#logArea() logArea()} or
+     * {@link Builder#logArea(int) logArea(int)}.
      */
     public static void logClear() {
         System.out.println("\nPassFailJFrame: log cleared\n");
@@ -1133,7 +1135,9 @@ public final class PassFailJFrame {
 
     /**
      * Replaces the log area content with provided {@code text}, if enabled by
-     * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
+     * {@link Builder#logArea() logArea()} or
+     * {@link Builder#logArea(int) logArea(int)}.
+     *
      * @param text new text for the log area
      */
     public static void logSet(String text) {


### PR DESCRIPTION
A clean backport of a small update to the documentation of `PassFailJFrame`.

> This pull request contains a backport of commit [833ff299](https://github.com/openjdk/jdk/commit/833ff29983e0d433ccd4c7e946b15e42045faeaa) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
>
> The commit being backported was authored by Alexey Ivanov on 23 Sep 2024 and was reviewed by Alexander Zvegintsev and Phil Race.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340461](https://bugs.openjdk.org/browse/JDK-8340461) needs maintainer approval

### Issue
 * [JDK-8340461](https://bugs.openjdk.org/browse/JDK-8340461): Amend description for logArea (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/143.diff">https://git.openjdk.org/jdk23u/pull/143.diff</a>

</details>
