### PR TITLE
8341658: RISC-V: Test DateFormatProviderTest.java run timeouted

### DIFF
--- a/test/jdk/java/util/PluggableLocale/DateFormatProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/DateFormatProviderTest.java
@@ -31,7 +31,7 @@
  *          java.base/sun.util.resources
  * @build com.foobar.Utils
  *        com.foo.*
- * @run main/othervm -Djava.locale.providers=CLDR,SPI DateFormatProviderTest
+ * @run main/othervm/timeout=300 -Djava.locale.providers=CLDR,SPI DateFormatProviderTest
  */
 
 import java.text.DateFormat;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d809bc0e](https://github.com/openjdk/jdk/commit/d809bc0e21b145758f21c4324772faf6aa6a276a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 9 Oct 2024 and was reviewed by Naoto Sato.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341658](https://bugs.openjdk.org/browse/JDK-8341658) needs maintainer approval

### Issue
 * [JDK-8341658](https://bugs.openjdk.org/browse/JDK-8341658): RISC-V: Test DateFormatProviderTest.java run timeouted (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/144.diff">https://git.openjdk.org/jdk23u/pull/144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/144#issuecomment-2401391789)