### PR TITLE
8338884: java/nio/file/attribute/BasicFileAttributeView/CreationTime.java#tmp fails on alinux3

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -114,6 +114,8 @@ ifeq ($(call isTargetOs, linux), true)
   # stripping during the test libraries' build.
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libFib := -g
   BUILD_JDK_JTREG_LIBRARIES_STRIP_SYMBOLS_libFib := false
+  # nio tests' libCreationTimeHelper native needs -ldl linker flag
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libCreationTimeHelper := -ldl
 endif
 
 ifeq ($(ASAN_ENABLED), true)

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +26,18 @@
  * @bug 8011536 8151430 8316304 8334339
  * @summary Basic test for creationTime attribute on platforms/file systems
  *     that support it, tests using /tmp directory.
- * @library  ../.. /test/lib
- * @build jdk.test.lib.Platform
- * @run main CreationTime
+ * @library  ../.. /test/lib /java/foreign
+ * @build jdk.test.lib.Platform NativeTestHelper
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED CreationTime
  */
 
 /* @test id=cwd
  * @summary Basic test for creationTime attribute on platforms/file systems
  *     that support it, tests using the test scratch directory, the test
  *     scratch directory maybe at diff disk partition to /tmp on linux.
- * @library  ../.. /test/lib
- * @build jdk.test.lib.Platform
- * @run main CreationTime .
+ * @library  ../.. /test/lib /java/foreign
+ * @build jdk.test.lib.Platform NativeTestHelper
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED CreationTime .
  */
 
 import java.lang.foreign.Linker;
@@ -50,8 +51,6 @@ import jdk.test.lib.Platform;
 import jtreg.SkippedException;
 
 public class CreationTime {
-
-    private static final java.io.PrintStream err = System.err;
 
     /**
      * Reads the creationTime attribute
@@ -78,14 +77,9 @@ public class CreationTime {
         FileTime creationTime = creationTime(file);
         Instant now = Instant.now();
         if (Math.abs(creationTime.toMillis()-now.toEpochMilli()) > 10000L) {
-            System.out.println("creationTime.toMillis() == " + creationTime.toMillis());
-            // If the file system doesn't support birth time, then skip this test
-            if (creationTime.toMillis() == 0) {
-                throw new SkippedException("birth time not support for: " + file);
-            } else {
-                err.println("File creation time reported as: " + creationTime);
-                throw new RuntimeException("Expected to be close to: " + now);
-            }
+            System.err.println("creationTime.toMillis() == " + creationTime.toMillis());
+            System.err.println("File creation time reported as: " + creationTime);
+            throw new RuntimeException("Expected to be close to: " + now);
         }
 
         /**
@@ -107,7 +101,12 @@ public class CreationTime {
             }
         } else if (Platform.isLinux()) {
             // Creation time read depends on statx system call support
-            supportsCreationTimeRead = Linker.nativeLinker().defaultLookup().find("statx").isPresent();
+            try {
+                supportsCreationTimeRead = CreationTimeHelper.
+                        linuxIsCreationTimeSupported(file.toAbsolutePath().toString());
+            } catch (Throwable e) {
+                supportsCreationTimeRead = false;
+            }
             // Creation time updates are not supported on Linux
             supportsCreationTimeWrite = false;
         }
@@ -122,8 +121,11 @@ public class CreationTime {
             Instant plusHour = Instant.now().plusSeconds(60L * 60L);
             Files.setLastModifiedTime(file, FileTime.from(plusHour));
             FileTime current = creationTime(file);
-            if (!current.equals(creationTime))
+            if (!current.equals(creationTime)) {
+                System.err.println("current = " + current);
+                System.err.println("creationTime = " + creationTime);
                 throw new RuntimeException("Creation time should not have changed");
+            }
         }
 
         /**

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+public class CreationTimeHelper extends NativeTestHelper {
+
+    static {
+        System.loadLibrary("CreationTimeHelper");
+    }
+
+    final static Linker abi = Linker.nativeLinker();
+    static final SymbolLookup lookup = SymbolLookup.loaderLookup();
+    final static MethodHandle methodHandle = abi.
+            downcallHandle(lookup.findOrThrow("linuxIsCreationTimeSupported"),
+            FunctionDescriptor.of(C_BOOL, C_POINTER));
+
+    // Helper so as to determine birth time support or not on Linux.
+    // Support is determined in a two-step process:
+    // 1. Determine if `statx` system call is available. If available proceed,
+    //    otherwise return false.
+    // 2. Perform an actual `statx` call on the given file and check for birth
+    //    time support in the mask returned from the call. This is needed,
+    //    since some file systems, like nfs/tmpfs etc., don't support birth
+    //    time even though the `statx` system call is available.
+    static boolean linuxIsCreationTimeSupported(String file) throws Throwable {
+        if (!abi.defaultLookup().find("statx").isPresent()) {
+            return false;
+        }
+        try (var arena = Arena.ofConfined()) {
+            MemorySegment s = arena.allocateFrom(file);
+            return (boolean)methodHandle.invokeExact(s);
+        }
+    }
+}

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include "export.h"
+#include <stdbool.h>
+#if defined(__linux__)
+#include <linux/fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <bits/types.h>
+#include <dlfcn.h>
+#ifndef STATX_BASIC_STATS
+#define STATX_BASIC_STATS 0x000007ffU
+#endif
+#ifndef STATX_BTIME
+#define STATX_BTIME 0x00000800U
+#endif
+#ifndef RTLD_DEFAULT
+#define RTLD_DEFAULT RTLD_LOCAL
+#endif
+
+/*
+ * Timestamp structure for the timestamps in struct statx.
+ */
+struct my_statx_timestamp {
+        __int64_t   tv_sec;
+        __uint32_t  tv_nsec;
+        __int32_t   __reserved;
+};
+
+/*
+ * struct statx used by statx system call on >= glibc 2.28
+ * systems
+ */
+struct my_statx
+{
+  __uint32_t stx_mask;
+  __uint32_t stx_blksize;
+  __uint64_t stx_attributes;
+  __uint32_t stx_nlink;
+  __uint32_t stx_uid;
+  __uint32_t stx_gid;
+  __uint16_t stx_mode;
+  __uint16_t __statx_pad1[1];
+  __uint64_t stx_ino;
+  __uint64_t stx_size;
+  __uint64_t stx_blocks;
+  __uint64_t stx_attributes_mask;
+  struct my_statx_timestamp stx_atime;
+  struct my_statx_timestamp stx_btime;
+  struct my_statx_timestamp stx_ctime;
+  struct my_statx_timestamp stx_mtime;
+  __uint32_t stx_rdev_major;
+  __uint32_t stx_rdev_minor;
+  __uint32_t stx_dev_major;
+  __uint32_t stx_dev_minor;
+  __uint64_t __statx_pad2[14];
+};
+
+typedef int statx_func(int dirfd, const char *restrict pathname, int flags,
+                       unsigned int mask, struct my_statx *restrict statxbuf);
+
+static statx_func* my_statx_func = NULL;
+#endif  //#defined(__linux__)
+
+// static boolean linuxIsCreationTimeSupported(char* file)
+EXPORT bool linuxIsCreationTimeSupported(char* file) {
+#if defined(__linux__)
+    struct my_statx stx = {0};
+    int ret, atflag = AT_SYMLINK_NOFOLLOW;
+    unsigned int mask = STATX_BASIC_STATS | STATX_BTIME;
+
+    my_statx_func = (statx_func*) dlsym(RTLD_DEFAULT, "statx");
+    if (my_statx_func == NULL) {
+        return false;
+    }
+
+    if (file == NULL) {
+        printf("input file error!\n");
+        return false;
+    }
+
+    ret = my_statx_func(AT_FDCWD, file, atflag, mask, &stx);
+    if (ret != 0) {
+        return false;
+    }
+    // On some systems where statx is available but birth time might still not
+    // be supported as it's file system specific. The only reliable way to
+    // check for supported or not is looking at the filled in STATX_BTIME bit
+    // in the returned statx buffer mask.
+    if ((stx.stx_mask & STATX_BTIME) != 0)
+        return true;
+    return false;
+#else
+    return false;
+#endif
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9d621d39](https://github.com/openjdk/jdk/commit/9d621d3914b39cfdcda97274a7af5ca0fe062d35) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 10 Oct 2024 and was reviewed by Severin Gehwolf and Brian Burkhalter.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8338884](https://bugs.openjdk.org/browse/JDK-8338884) needs maintainer approval

### Issue
 * [JDK-8338884](https://bugs.openjdk.org/browse/JDK-8338884): java/nio/file/attribute/BasicFileAttributeView/CreationTime.java#tmp fails on alinux3 (**Bug** - P3 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/147.diff">https://git.openjdk.org/jdk23u/pull/147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/147#issuecomment-2403711958)