### PR TITLE
8340812: LambdaForm customization via MethodHandle::updateForm is not thread safe

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1891,8 +1891,7 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
                 if (oldForm != newForm) {
                     assert (newForm.customized == null || newForm.customized == this);
                     newForm.prepare(); // as in MethodHandle.<init>
-                    UNSAFE.putReference(this, FORM_OFFSET, newForm);
-                    UNSAFE.fullFence();
+                    UNSAFE.putReferenceRelease(this, FORM_OFFSET, newForm); // properly publish newForm
                 }
             } finally {
                 updateInProgress = false;

--- a/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
+++ b/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+
+/**
+  * @test
+  * @bug 8340812
+  * @summary Verify that LambdaForm customization via MethodHandle::updateForm is thread safe.
+  * @run main TestLambdaFormCustomization
+  * @run main/othervm -Djava.lang.invoke.MethodHandle.CUSTOMIZE_THRESHOLD=0 TestLambdaFormCustomization
+  */
+public class TestLambdaFormCustomization {
+
+    String str = "test";
+    static final String value = "test" + 42;
+
+    // Trigger concurrent LambdaForm customization for VarHandle invokers
+    void test() throws NoSuchFieldException, IllegalAccessException {
+        VarHandle varHandle = MethodHandles.lookup().in(getClass()).findVarHandle(getClass(), "str", String.class);
+
+        ArrayList<Thread> threads = new ArrayList<>();
+        for (int threadIdx = 0; threadIdx < 10; threadIdx++) {
+            threads.add(new Thread(() -> {
+                for (int i = 0; i < 1000; i++) {
+                    varHandle.compareAndExchange(this, value, value);
+                    varHandle.compareAndExchange(this, value, value);
+                    varHandle.compareAndExchange(this, value, value);
+                }
+            }));
+        }
+        threads.forEach(Thread::start);
+        threads.forEach(t -> {
+            try {
+                t.join();
+            } catch (Throwable e) {
+                throw new IllegalStateException(e);
+            }
+        });
+    }
+
+    public static void main(String[] args) throws Exception {
+        TestLambdaFormCustomization t = new TestLambdaFormCustomization();
+        for (int i = 0; i < 4000; ++i) {
+            t.test();
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [47c10694](https://github.com/openjdk/jdk/commit/47c10694c66bc131c8a5e1572340415b8daaba08) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Tobias Hartmann on 26 Sep 2024 and was reviewed by Chen Liang, Aleksey Shipilev and Jorn Vernee.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340812](https://bugs.openjdk.org/browse/JDK-8340812) needs maintainer approval

### Issue
 * [JDK-8340812](https://bugs.openjdk.org/browse/JDK-8340812): LambdaForm customization via MethodHandle::updateForm is not thread safe (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/149.diff">https://git.openjdk.org/jdk23u/pull/149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/149#issuecomment-2404033054)