### PR TITLE
8335142: compiler/c1/TestTraceLinearScanLevel.java occasionally times out with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestTraceLinearScanLevel.java
+++ b/test/hotspot/jtreg/compiler/c1/TestTraceLinearScanLevel.java
@@ -26,8 +26,8 @@
  * @bug 8251093
  * @summary Sanity check the flag TraceLinearScanLevel with the highest level in a silent HelloWorld program.
  *
- * @requires vm.debug == true & vm.compiler1.enabled
- * @run main/othervm -XX:TraceLinearScanLevel=4 compiler.c1.TestTraceLinearScanLevel
+ * @requires vm.debug == true & vm.compiler1.enabled & vm.compMode != "Xcomp"
+ * @run main/othervm -Xbatch -XX:TraceLinearScanLevel=4 compiler.c1.TestTraceLinearScanLevel
  */
 package compiler.c1;
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6f4ddc2f](https://github.com/openjdk/jdk/commit/6f4ddc2f6bf0dd9a626a76d0f5e56a54c6cf6b65) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christian Hagedorn on 28 Jun 2024 and was reviewed by Tobias Hartmann and Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335142](https://bugs.openjdk.org/browse/JDK-8335142) needs maintainer approval

### Issue
 * [JDK-8335142](https://bugs.openjdk.org/browse/JDK-8335142): compiler/c1/TestTraceLinearScanLevel.java occasionally times out with -Xcomp (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/150.diff">https://git.openjdk.org/jdk23u/pull/150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/150#issuecomment-2404071921)