### PR TITLE
8335530: Java file extension missing in AuthenticatorTest

### DIFF
--- a/test/jdk/com/sun/net/httpserver/AuthenticatorTest.java
+++ b/test/jdk/com/sun/net/httpserver/AuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,36 +25,36 @@
  * @test
  * @bug 8251496
  * @summary Tests for methods in Authenticator
- * @run testng/othervm AuthenticatorTest
+ * @run junit AuthenticatorTest
  */
 
 import com.sun.net.httpserver.Authenticator;
-import com.sun.net.httpserver.BasicAuthenticator;
 import com.sun.net.httpserver.HttpPrincipal;
-import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class AuthenticatorTest {
     @Test
     public void testFailure() {
         var failureResult = new Authenticator.Failure(666);
-        assertEquals(failureResult.getResponseCode(), 666);
+        assertEquals(666, failureResult.getResponseCode());
     }
 
     @Test
     public void testRetry() {
         var retryResult = new Authenticator.Retry(333);
-        assertEquals(retryResult.getResponseCode(), 333);
+        assertEquals(333, retryResult.getResponseCode());
     }
 
     @Test
-    public void TestSuccess() {
+    public void testSuccess() {
         var principal = new HttpPrincipal("test", "123");
         var successResult = new Authenticator.Success(principal);
-        assertEquals(successResult.getPrincipal(), principal);
-        assertEquals("test", principal.getName());
+        assertEquals(principal, successResult.getPrincipal());
+        assertEquals("test", principal.getUsername());
         assertEquals("123", principal.getRealm());
     }
 }


### PR DESCRIPTION
clean backport of https://git.openjdk.org/jdk/commit/a537e87d2d2c6bff63f63bb436e3e919740221ce

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335530](https://bugs.openjdk.org/browse/JDK-8335530) needs maintainer approval

### Issue
 * [JDK-8335530](https://bugs.openjdk.org/browse/JDK-8335530): Java file extension missing in AuthenticatorTest (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/153.diff">https://git.openjdk.org/jdk23u/pull/153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/153#issuecomment-2404854078)