### PR TITLE
8333306: gc/arguments/TestParallelGCErgo.java fails when largepage are enabled

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestParallelGCErgo.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelGCErgo.java
@@ -27,6 +27,7 @@ package gc.arguments;
  * @test TestParallelGCErgo
  * @bug 8272364
  * @requires vm.gc.Parallel
+ * @requires vm.opt.UseLargePages == null | !vm.opt.UseLargePages
  * @summary Verify ParallelGC minimum young and old ergonomics are setup correctly
  * @modules java.base/jdk.internal.misc
  * @library /test/lib


### PR DESCRIPTION
Clean backport. Fixes a bad configuration for an ergonomics test.
Tested locally with -XX:+UseLargePages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333306](https://bugs.openjdk.org/browse/JDK-8333306) needs maintainer approval

### Issue
 * [JDK-8333306](https://bugs.openjdk.org/browse/JDK-8333306): gc/arguments/TestParallelGCErgo.java fails when largepage are enabled (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/157.diff">https://git.openjdk.org/jdk23u/pull/157.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/157#issuecomment-2407186770)