### PR TITLE
8340073: Support "%z" time zone abbreviation format in TZ files

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -786,7 +786,10 @@ public class CLDRConverter {
             String tzKey = Optional.ofNullable((String)handlerSupplMeta.get(tzid))
                                    .orElse(tzid);
             // Follow link, if needed
-            var tzLink = tzdbLinks.get(tzKey);
+            String tzLink = null;
+            for (var k = tzKey; tzdbLinks.containsKey(k);) {
+                k = tzLink = tzdbLinks.get(k);
+            }
             if (tzLink == null && tzdbLinks.containsValue(tzKey)) {
                 // reverse link search
                 // this is needed as in tzdb, "America/Buenos_Aires" links to
@@ -1214,7 +1217,7 @@ public class CLDRConverter {
     private static Set<String> getAvailableZoneIds() {
         assert handlerMetaZones != null;
         if (AVAILABLE_TZIDS == null) {
-            AVAILABLE_TZIDS = new HashSet<>(ZoneId.getAvailableZoneIds());
+            AVAILABLE_TZIDS = new HashSet<>(Arrays.asList(TimeZone.getAvailableIDs()));
             AVAILABLE_TZIDS.addAll(handlerMetaZones.keySet());
             AVAILABLE_TZIDS.remove(MetaZonesParseHandler.NO_METAZONE_KEY);
         }
@@ -1491,13 +1494,14 @@ public class CLDRConverter {
     /*
      * Convert TZDB offsets to JDK's offsets, eg, "-08" to "GMT-08:00".
      * If it cannot recognize the pattern, return the argument as is.
+     * Returning null results in generating the GMT format at runtime.
      */
     private static String convertGMTName(String f) {
         try {
-            // Should pre-fill GMT format once COMPAT is gone.
-            // Till then, fall back to GMT format at runtime, after COMPAT short
-            // names are populated
-            ZoneOffset.of(f);
+            if (!f.equals("%z")) {
+                // Validate if the format is an offset
+                ZoneOffset.of(f);
+            }
             return null;
         } catch (DateTimeException dte) {
             // textual representation. return as is

--- a/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
@@ -264,7 +264,13 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
     }
 
     private String toGMTFormat(String id, boolean daylight, Locale l) {
-        var zr = ZoneInfoFile.getZoneInfo(id).toZoneId().getRules();
+        LocaleResources lr = LocaleProviderAdapter.forType(Type.CLDR).getLocaleResources(l);
+        ResourceBundle fd = lr.getJavaTimeFormatData();
+        var zi = ZoneInfoFile.getZoneInfo(id);
+        if (zi == null) {
+            return fd.getString("timezone.gmtZeroFormat");
+        }
+        var zr = zi.toZoneId().getRules();
         var now = Instant.now();
         var saving = zr.getTransitions().reversed().stream()
                 .dropWhile(zot -> zot.getInstant().isAfter(now))
@@ -276,8 +282,6 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
                 .orElse(0);
         int offset = (zr.getStandardOffset(now).getTotalSeconds() +
                 (daylight ? saving : 0)) / 60;
-        LocaleResources lr = LocaleProviderAdapter.forType(Type.CLDR).getLocaleResources(l);
-        ResourceBundle fd = lr.getJavaTimeFormatData();
 
         if (offset == 0) {
             return fd.getString("timezone.gmtZeroFormat");


### PR DESCRIPTION
Clean backport of https://git.openjdk.org/jdk/commit/418bb42b95b177f5f31f756054d0dd83740c6686

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340073](https://bugs.openjdk.org/browse/JDK-8340073) needs maintainer approval

### Issue
 * [JDK-8340073](https://bugs.openjdk.org/browse/JDK-8340073): Support "%z" time zone abbreviation format in TZ files (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/158.diff">https://git.openjdk.org/jdk23u/pull/158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/158#issuecomment-2409961734)