### PR TITLE
8337886: java/awt/Frame/MaximizeUndecoratedTest.java fails in OEL due to a slight color difference

### DIFF
--- a/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
+++ b/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
@@ -50,7 +50,7 @@ import jtreg.SkippedException;
 
 public class MaximizeUndecoratedTest {
     private static final int SIZE = 300;
-    private static final int OFFSET = 2;
+    private static final int OFFSET = 5;
 
     private static Frame frame;
     private static Robot robot;


### PR DESCRIPTION
Backporting to 23u should not be skipped.

The patch applies cleanly.

> This pull request contains a backport of commit [15b20cb1](https://github.com/openjdk/jdk/commit/15b20cb1fd18b849e49c175737dd3826c8d0ceff) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
>
> The commit being backported was authored by Manukumar V S on 19 Aug 2024 and was reviewed by Damon Nguyen, Harshitha Onkar and Sergey Bylokhov.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337886](https://bugs.openjdk.org/browse/JDK-8337886) needs maintainer approval

### Issue
 * [JDK-8337886](https://bugs.openjdk.org/browse/JDK-8337886): java/awt/Frame/MaximizeUndecoratedTest.java fails in OEL due to a slight color difference (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/167/head:pull/167` \
`$ git checkout pull/167`

Update a local copy of the PR: \
`$ git checkout pull/167` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 167`

View PR using the GUI difftool: \
`$ git pr show -t 167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/167.diff">https://git.openjdk.org/jdk23u/pull/167.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/167#issuecomment-2412037085)