### PR TITLE
8340365: Position the first window of a window list

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -349,11 +349,9 @@ public final class PassFailJFrame {
                         builder.positionWindows
                                .positionTestWindows(unmodifiableList(builder.testWindows),
                                                     builder.instructionUIHandler));
-            } else if (builder.testWindows.size() == 1) {
+            } else {
                 Window window = builder.testWindows.get(0);
                 positionTestWindow(window, builder.position);
-            } else {
-                positionTestWindow(null, builder.position);
             }
         }
         showAllWindows();


### PR DESCRIPTION
This pull request contains a backport of commit [e97f0fe1](https://github.com/openjdk/jdk/commit/e97f0fe1b4046bfcc40e85ba1bee4f4c40053300) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexey Ivanov on 23 Sep 2024 and was reviewed by Alexander Zvegintsev and Phil Race.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8340365](https://bugs.openjdk.org/browse/JDK-8340365) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340365](https://bugs.openjdk.org/browse/JDK-8340365): Position the first window of a window list (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/169.diff">https://git.openjdk.org/jdk23u/pull/169.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/169#issuecomment-2412077728)