### PR TITLE
8333391: Test com/sun/jdi/InterruptHangTest.java failed: Thread was never interrupted during sleep

### DIFF
--- a/test/jdk/com/sun/jdi/InterruptHangTest.java
+++ b/test/jdk/com/sun/jdi/InterruptHangTest.java
@@ -101,8 +101,10 @@ class InterruptHangTarg {
         for (int ii = 0; ii < INTERRUPTS_EXPECTED; ii++) {
             boolean wasInterrupted = false;
             try {
-                // Give other thread a chance to interrupt
-                Thread.sleep(100);
+                // Give other thread a chance to interrupt. Normally only a very short
+                // sleep is needed, but we need to account for unexpected delays in
+                // the interrupt due to machine and network hiccups.
+                Thread.sleep(10*1000);
             } catch (InterruptedException ee) {
                 answer++;
                 wasInterrupted = true;


### PR DESCRIPTION
Clean backport. Increased sleep time. Tested in mach5 in aarch64 and all other platforms.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8333391](https://bugs.openjdk.org/browse/JDK-8333391) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333391](https://bugs.openjdk.org/browse/JDK-8333391): Test com/sun/jdi/InterruptHangTest.java failed: Thread was never interrupted during sleep (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/175.diff">https://git.openjdk.org/jdk23u/pull/175.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/175#issuecomment-2416292384)