### PR TITLE
8340799: Add border inside instruction frame in PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -24,6 +24,7 @@
 import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
@@ -69,6 +70,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JTextArea;
 import javax.swing.Timer;
+import javax.swing.border.Border;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.StyleSheet;
@@ -655,6 +657,8 @@ public final class PassFailJFrame {
                                                        boolean addLogArea,
                                                        int logAreaRows) {
         JPanel main = new JPanel(new BorderLayout());
+        main.setBorder(createFrameBorder());
+
         timeoutHandlerPanel = new TimeoutHandlerPanel(testTimeOut);
         main.add(timeoutHandlerPanel, BorderLayout.NORTH);
 
@@ -664,7 +668,7 @@ public final class PassFailJFrame {
         text.setEditable(false);
 
         JPanel textPanel = new JPanel(new BorderLayout());
-        textPanel.setBorder(createEmptyBorder(4, 0, 0, 0));
+        textPanel.setBorder(createEmptyBorder(GAP, 0, GAP, 0));
         textPanel.add(new JScrollPane(text), BorderLayout.CENTER);
 
         main.add(textPanel, BorderLayout.CENTER);
@@ -681,7 +685,8 @@ public final class PassFailJFrame {
             timeoutHandlerPanel.stop();
         });
 
-        JPanel buttonsPanel = new JPanel();
+        JPanel buttonsPanel = new JPanel(new FlowLayout(FlowLayout.CENTER,
+                                                        GAP, 0));
         buttonsPanel.add(btnPass);
         buttonsPanel.add(btnFail);
 
@@ -692,10 +697,12 @@ public final class PassFailJFrame {
         if (addLogArea) {
             logArea = new JTextArea(logAreaRows, columns);
             logArea.setEditable(false);
+            logArea.setBorder(createTextBorder());
 
             Box buttonsLogPanel = Box.createVerticalBox();
 
             buttonsLogPanel.add(buttonsPanel);
+            buttonsLogPanel.add(Box.createVerticalStrut(GAP));
             buttonsLogPanel.add(new JScrollPane(logArea));
 
             main.add(buttonsLogPanel, BorderLayout.SOUTH);
@@ -713,7 +720,7 @@ public final class PassFailJFrame {
         JTextArea text = new JTextArea(instructions, rows, columns);
         text.setLineWrap(true);
         text.setWrapStyleWord(true);
-        text.setBorder(createEmptyBorder(4, 4, 4, 4));
+        text.setBorder(createTextBorder());
         return text;
     }
 
@@ -733,6 +740,29 @@ public final class PassFailJFrame {
         styles.addRule("code { font-size: inherit }");
 
         return text;
+    }
+
+    /** A default gap between components. */
+    private static final int GAP = 4;
+
+    /**
+     * Creates a default border for frames or dialogs.
+     * It uses the default gap of {@value GAP}.
+     *
+     * @return the border for frames and dialogs
+     */
+    private static Border createFrameBorder() {
+        return createEmptyBorder(GAP, GAP, GAP, GAP);
+    }
+
+    /**
+     * Creates a border set to text area.
+     * It uses the default gap of {@value GAP}.
+     *
+     * @return the border for text area
+     */
+    private static Border createTextBorder() {
+        return createEmptyBorder(GAP, GAP, GAP, GAP);
     }
 
 
@@ -1086,26 +1116,30 @@ public final class PassFailJFrame {
      * Requests the description of the test failure reason from the tester.
      */
     private static void requestFailureReason() {
-        final JDialog dialog = new JDialog(frame, "Test Failure ", true);
-        dialog.setTitle("Failure reason");
-        JPanel jPanel = new JPanel(new BorderLayout());
-        JTextArea jTextArea = new JTextArea(5, 20);
+        final JDialog dialog = new JDialog(frame, "Failure reason", true);
+
+        JTextArea reason = new JTextArea(5, 20);
+        reason.setBorder(createTextBorder());
 
         JButton okButton = new JButton("OK");
         okButton.addActionListener((ae) -> {
-            String text = jTextArea.getText();
+            String text = reason.getText();
             setFailureReason(FAILURE_REASON
                              + (!text.isEmpty() ? text : EMPTY_REASON));
             dialog.setVisible(false);
         });
 
-        jPanel.add(new JScrollPane(jTextArea), BorderLayout.CENTER);
-
-        JPanel okayBtnPanel = new JPanel();
+        JPanel okayBtnPanel = new JPanel(new FlowLayout(FlowLayout.CENTER,
+                                                        GAP, 0));
+        okayBtnPanel.setBorder(createEmptyBorder(GAP, 0, 0, 0));
         okayBtnPanel.add(okButton);
 
-        jPanel.add(okayBtnPanel, BorderLayout.SOUTH);
-        dialog.add(jPanel);
+        JPanel main = new JPanel(new BorderLayout());
+        main.setBorder(createFrameBorder());
+        main.add(new JScrollPane(reason), BorderLayout.CENTER);
+        main.add(okayBtnPanel, BorderLayout.SOUTH);
+
+        dialog.add(main);
         dialog.setLocationRelativeTo(frame);
         dialog.pack();
         dialog.setVisible(true);


### PR DESCRIPTION
This pull request contains a backport of commit [520060f7](https://github.com/openjdk/jdk/commit/520060f79a3cedb8f93e6bbd0e9b2823eaabf79a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexey Ivanov on 7 Oct 2024 and was reviewed by Phil Race and Damon Nguyen.

The patch applies cleanly after backporting #171 ([JDK-8340466](https://bugs.openjdk.org/browse/JDK-8340466)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8340799](https://bugs.openjdk.org/browse/JDK-8340799) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340799](https://bugs.openjdk.org/browse/JDK-8340799): Add border inside instruction frame in PassFailJFrame (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/177/head:pull/177` \
`$ git checkout pull/177`

Update a local copy of the PR: \
`$ git checkout pull/177` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 177`

View PR using the GUI difftool: \
`$ git pr show -t 177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/177.diff">https://git.openjdk.org/jdk23u/pull/177.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/177#issuecomment-2413550785)