### PR TITLE
8341235: Improve default instruction frame title in PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -44,6 +44,7 @@ import java.awt.image.RenderedImage;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -165,9 +166,15 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  */
 public final class PassFailJFrame {
 
-    private static final String TITLE = "Test Instruction Frame";
+    /** A default title for the instruction frame. */
+    private static final String TITLE = "Test Instructions";
+
+    /** A default test timeout. */
     private static final long TEST_TIMEOUT = 5;
+
+    /** A default number of rows for displaying the test instructions. */
     private static final int ROWS = 10;
+    /** A default number of columns for displaying the test instructions. */
     private static final int COLUMNS = 40;
 
     /**
@@ -175,7 +182,7 @@ public final class PassFailJFrame {
      */
     private static final String FAILURE_REASON = "Failure Reason:\n";
     /**
-     * The failure reason message when the user didn't provide one.
+     * The failure reason message when the user doesn't provide one.
      */
     private static final String EMPTY_REASON = "(no reason provided)";
 
@@ -1506,9 +1513,41 @@ public final class PassFailJFrame {
             return new PassFailJFrame(this);
         }
 
+        /**
+         * Returns the file name of the test, if the {@code test.file} property
+         * is defined, concatenated with {@code " - "} which serves as a prefix
+         * to the default instruction frame title;
+         * or an empty string if the {@code test.file} property is not defined.
+         *
+         * @return the prefix to the default title:
+         *         either the file name of the test or an empty string
+         *
+         * @see <a href="https://openjdk.org/jtreg/tag-spec.html#testvars">jtreg
+         * test-specific system properties and environment variables</a>
+         */
+        private static String getTestFileNamePrefix() {
+            String testFile = System.getProperty("test.file");
+            if (testFile == null) {
+                return "";
+            }
+
+            return Paths.get(testFile).getFileName().toString()
+                   + " - ";
+        }
+
+        /**
+         * Validates the state of the builder and
+         * expands parameters that have no assigned values
+         * to their default values.
+         *
+         * @throws IllegalStateException if no instructions are provided,
+         *              or if {@code PositionWindows} implementation is
+         *              provided but neither window creator nor
+         *              test window list are set
+         */
         private void validate() {
             if (title == null) {
-                title = TITLE;
+                title = getTestFileNamePrefix() + TITLE;
             }
 
             if (instructions == null || instructions.isEmpty()) {


### PR DESCRIPTION
This pull request contains a backport of commit [4ba170c4](https://github.com/openjdk/jdk/commit/4ba170c403ae85576f84dafd4a157ba0db99873f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexey Ivanov on 7 Oct 2024 and was reviewed by Phil Race.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8341235](https://bugs.openjdk.org/browse/JDK-8341235) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341235](https://bugs.openjdk.org/browse/JDK-8341235): Improve default instruction frame title in PassFailJFrame (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/178/head:pull/178` \
`$ git checkout pull/178`

Update a local copy of the PR: \
`$ git checkout pull/178` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 178`

View PR using the GUI difftool: \
`$ git pr show -t 178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/178.diff">https://git.openjdk.org/jdk23u/pull/178.diff</a>

</details>
