### PR TITLE
8337320: Update ProblemList.txt with tests known to fail on XWayland

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -470,6 +470,12 @@ sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 
+# Wayland related
+
+java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8332158 linux-x64
+java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java 8280991 linux-x64
+java/awt/FullScreen/SetFullScreenTest.java 8332155 linux-x64
+
 ############################################################################
 
 # jdk_beans


### PR DESCRIPTION
Updates the problem list with tests which fail on XWayland.

The patch does not apply cleanly, `SelectNewItemTest.java` has been removed from the problem list already.

Other than the context difference, the patch is identical.

> This pull request contains a backport of commit [ddbd7a78](https://github.com/openjdk/jdk/commit/ddbd7a78f191462695ecbeeef7fd6312e322b15a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
> 
> The commit being backported was authored by Alexander Zvegintsev on 8 Aug 2024 and was reviewed by Phil Race.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337320](https://bugs.openjdk.org/browse/JDK-8337320) needs maintainer approval

### Issue
 * [JDK-8337320](https://bugs.openjdk.org/browse/JDK-8337320): Update ProblemList.txt with tests known to fail on XWayland (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/186/head:pull/186` \
`$ git checkout pull/186`

Update a local copy of the PR: \
`$ git checkout pull/186` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 186`

View PR using the GUI difftool: \
`$ git pr show -t 186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/186.diff">https://git.openjdk.org/jdk23u/pull/186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/186#issuecomment-2417296752)