### PR TITLE
8341966: Broken annotated module may lead to an exception in javac

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2174,7 +2174,7 @@ public class ClassReader {
 
         Type resolvePossibleProxyType(Type t) {
             if (t instanceof ProxyType proxyType) {
-                Assert.check(requestingOwner.owner.kind == MDL);
+                Assert.check(requestingOwner.owner instanceof ModuleSymbol);
                 ModuleSymbol prevCurrentModule = currentModule;
                 currentModule = (ModuleSymbol) requestingOwner.owner;
                 try {

--- a/test/langtools/tools/javac/modules/AnnotationsOnModules.java
+++ b/test/langtools/tools/javac/modules/AnnotationsOnModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8159602 8170549 8171255 8171322 8254023
+ * @bug 8159602 8170549 8171255 8171322 8254023 8341966
  * @summary Test annotations on module declaration.
  * @library /tools/lib
  * @enablePreview
@@ -35,8 +35,10 @@
  */
 
 import java.io.File;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -55,6 +57,7 @@ import javax.lang.model.element.TypeElement;
 import java.lang.classfile.*;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.attribute.*;
+import java.lang.reflect.AccessFlag;
 import toolbox.JavacTask;
 import toolbox.Task;
 import toolbox.Task.OutputKind;
@@ -723,6 +726,93 @@ public class AnnotationsOnModules extends ModuleTestBase {
                 .files(findJavaFiles(extraSrc))
                 .run()
                 .writeAll();
+        }
+    }
+
+    @Test
+    public void testBrokenModuleInfoClassWithAnnotation(Path base) throws Exception {
+        Path lib = base.resolve("lib");
+        tb.writeJavaFiles(lib,
+                          """
+                          @Deprecated
+                          module m{}
+                          """);
+
+        Path libClasses = base.resolve("lib-classes");
+        Files.createDirectories(libClasses);
+
+        new JavacTask(tb)
+            .options("--release", "21")
+            .outdir(libClasses)
+            .files(findJavaFiles(lib))
+            .run()
+            .writeAll();
+
+        Path modifiedModuleInfo = libClasses.resolve("module-info.class");
+        ClassModel cm1 = ClassFile.of().parse(modifiedModuleInfo);
+        byte[] newBytes = ClassFile.of().transformClass(cm1, (builder, element) -> {
+            if (element instanceof ModuleAttribute attr) {
+                List<ModuleRequireInfo> requires = new ArrayList<>();
+
+                for (ModuleRequireInfo mri : attr.requires()) {
+                    if (mri.requires().name().equalsString("java.base")) {
+                        requires.add(ModuleRequireInfo.of(mri.requires(),
+                                                          List.of(AccessFlag.TRANSITIVE),
+                                                          mri.requiresVersion()
+                                                             .orElse(null)));
+                    } else {
+                        requires.add(mri);
+                    }
+                }
+
+                builder.accept(ModuleAttribute.of(attr.moduleName(),
+                                                  attr.moduleFlagsMask(),
+                                                  attr.moduleVersion()
+                                                      .orElseGet(() -> null),
+                                                  requires,
+                                                  attr.exports(),
+                                                  attr.opens(),
+                                                  attr.uses(),
+                                                  attr.provides()));
+            } else {
+                builder.accept(element);
+            }
+        });
+
+        try (OutputStream out = Files.newOutputStream(modifiedModuleInfo)) {
+            out.write(newBytes);
+        }
+
+        Path src = base.resolve("src");
+        Path classes = base.resolve("classes");
+
+        tb.writeJavaFiles(src,
+                          """
+                          public class C {}
+                          """);
+
+        Files.createDirectories(classes);
+
+        List<String> actualErrors =
+            new JavacTask(tb)
+                .options("--module-path", libClasses.toString(),
+                         "--add-modules", "m",
+                         "-XDshould-stop.at=FLOW",
+                         "-XDdev",
+                         "-XDrawDiagnostics")
+                .outdir(classes)
+                .files(findJavaFiles(src))
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+        List<String> expectedErrors = List.of(
+            "- compiler.err.cant.access: m.module-info, (compiler.misc.bad.class.file.header: module-info.class, (compiler.misc.bad.requires.flag: ACC_TRANSITIVE (0x0020))",
+            "1 error"
+        );
+
+        if (!expectedErrors.equals(actualErrors)) {
+            throw new AssertionError("Unexpected errors, expected: " + expectedErrors +
+                                     ", but got: " + actualErrors);
         }
     }
 

--- a/test/langtools/tools/javac/modules/AnnotationsOnModules.java
+++ b/test/langtools/tools/javac/modules/AnnotationsOnModules.java
@@ -750,7 +750,7 @@ public class AnnotationsOnModules extends ModuleTestBase {
 
         Path modifiedModuleInfo = libClasses.resolve("module-info.class");
         ClassModel cm1 = ClassFile.of().parse(modifiedModuleInfo);
-        byte[] newBytes = ClassFile.of().transformClass(cm1, (builder, element) -> {
+        byte[] newBytes = ClassFile.of().transform(cm1, (builder, element) -> {
             if (element instanceof ModuleAttribute attr) {
                 List<ModuleRequireInfo> requires = new ArrayList<>();
 


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [7ff4ea8d](https://github.com/openjdk/jdk/commit/7ff4ea8d01c681b90ad59be04007557d84c8db94) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Jan Lahoda on 17 Oct 2024 and was reviewed by Adam Sotona.

    Thanks!

The original description:

Consider a `module-info.class`, that both:
 - is wrong, so it will produce a bad-classfile error, for example due to an illegal `requires transitive java.base;`
 - and the module is annotated

If the javac proceeds to resolve the annotations (which is not the default, but can be pushed to do it), it will crash with an `AssertionError` while trying to un-proxy the annotations. This is because there's an assert that `requestingOwner.owner.kind == MDL`, but since the module is erroneous, the kind is `ERR`, and the assert fails.

The proposal is to loosen the assert a bit, and require `requestingOwner.owner instanceof ModuleSymbol`. That should still be sufficiently strong, while permitting broken modules to be handled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341966](https://bugs.openjdk.org/browse/JDK-8341966) needs maintainer approval

### Issue
 * [JDK-8341966](https://bugs.openjdk.org/browse/JDK-8341966): Broken annotated module may lead to an exception in javac (**Task** - P4 - Approved)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - no project role)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/192/head:pull/192` \
`$ git checkout pull/192`

Update a local copy of the PR: \
`$ git checkout pull/192` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 192`

View PR using the GUI difftool: \
`$ git pr show -t 192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/192.diff">https://git.openjdk.org/jdk23u/pull/192.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/192#issuecomment-2419041024)