### PR TITLE
8342145: File libCreationTimeHelper.c compile fails on Alpine

### DIFF
--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -25,8 +25,8 @@
 #if defined(__linux__)
 #include <stdio.h>
 #include <string.h>
+#include <sys/types.h>
 #include <sys/stat.h>
-#include <bits/types.h>
 #include <dlfcn.h>
 #ifndef STATX_BASIC_STATS
 #define STATX_BASIC_STATS 0x000007ffU
@@ -44,13 +44,20 @@
 #define AT_FDCWD -100
 #endif
 
+#ifndef __GLIBC__
+// Alpine doesn't know these types, define them
+typedef unsigned int       __uint32_t;
+typedef unsigned short     __uint16_t;
+typedef unsigned long int  __uint64_t;
+#endif
+
 /*
  * Timestamp structure for the timestamps in struct statx.
  */
 struct my_statx_timestamp {
-        __int64_t   tv_sec;
+        int64_t   tv_sec;
         __uint32_t  tv_nsec;
-        __int32_t   __reserved;
+        int32_t   __reserved;
 };
 
 /*


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [44151f47](https://github.com/openjdk/jdk/commit/44151f475fca3cf03299319b2ac9ddc533ba134d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 16 Oct 2024 and was reviewed by Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342145](https://bugs.openjdk.org/browse/JDK-8342145) needs maintainer approval

### Issue
 * [JDK-8342145](https://bugs.openjdk.org/browse/JDK-8342145): File libCreationTimeHelper.c compile fails on Alpine (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/195/head:pull/195` \
`$ git checkout pull/195`

Update a local copy of the PR: \
`$ git checkout pull/195` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 195`

View PR using the GUI difftool: \
`$ git pr show -t 195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/195.diff">https://git.openjdk.org/jdk23u/pull/195.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/195#issuecomment-2421631677)