### PR TITLE
8340824: C2: Memory for TypeInterfaces not reclaimed by hashcons()

### DIFF
--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -877,19 +877,18 @@ public:
 // Set of implemented interfaces. Referenced from TypeOopPtr and TypeKlassPtr.
 class TypeInterfaces : public Type {
 private:
-  GrowableArray<ciInstanceKlass*> _list;
+  GrowableArrayFromArray<ciInstanceKlass*> _interfaces;
   uint _hash;
   ciInstanceKlass* _exact_klass;
   DEBUG_ONLY(bool _initialized;)
 
   void initialize();
 
-  void add(ciInstanceKlass* interface);
   void verify() const NOT_DEBUG_RETURN;
   void compute_hash();
   void compute_exact_klass();
-  TypeInterfaces();
-  TypeInterfaces(GrowableArray<ciInstanceKlass*>* interfaces);
+
+  TypeInterfaces(ciInstanceKlass** interfaces_base, int nb_interfaces);
 
   NONCOPYABLE(TypeInterfaces);
 public:
@@ -904,12 +903,13 @@ public:
   bool contains(const TypeInterfaces* other) const {
     return intersection_with(other)->eq(other);
   }
-  bool empty() const { return _list.length() == 0; }
+  bool empty() const { return _interfaces.length() == 0; }
 
   ciInstanceKlass* exact_klass() const;
   void verify_is_loaded() const NOT_DEBUG_RETURN;
 
   static int compare(ciInstanceKlass* const& k1, ciInstanceKlass* const& k2);
+  static int compare(ciInstanceKlass** k1, ciInstanceKlass** k2);
 
   const Type* xmeet(const Type* t) const;
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [90c944fe](https://github.com/openjdk/jdk/commit/90c944fefe4a7827c08a8e6a81f137c3157a749b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The change applied cleanly.

The commit being backported was authored by Roland Westrelin on 2 Oct 2024 and was reviewed by Vladimir Ivanov and Quan Anh Mai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340824](https://bugs.openjdk.org/browse/JDK-8340824) needs maintainer approval

### Issue
 * [JDK-8340824](https://bugs.openjdk.org/browse/JDK-8340824): C2: Memory for TypeInterfaces not reclaimed by hashcons() (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/197/head:pull/197` \
`$ git checkout pull/197`

Update a local copy of the PR: \
`$ git checkout pull/197` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 197`

View PR using the GUI difftool: \
`$ git pr show -t 197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/197.diff">https://git.openjdk.org/jdk23u/pull/197.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/197#issuecomment-2422437531)