### PR TITLE
8342612: Increase memory usage of compiler/c2/TestScalarReplacementMaxLiveNodes.java

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestScalarReplacementMaxLiveNodes.java
+++ b/test/hotspot/jtreg/compiler/c2/TestScalarReplacementMaxLiveNodes.java
@@ -36,6 +36,7 @@
  *                   -XX:CompileCommand=inline,*String*::*
  *                   -XX:CompileCommand=dontinline,*StringBuilder*::ensureCapacityInternal
  *                   -XX:CompileCommand=dontinline,*String*::substring
+ *                   -XX:CompileCommand=MemLimit,*.*,0
  *                   -XX:NodeCountInliningCutoff=220000
  *                   -XX:DesiredMethodLimit=100000
  *                   compiler.c2.TestScalarReplacementMaxLiveNodes


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [21682bcd](https://github.com/openjdk/jdk/commit/21682bcdccbb35286cbffc21517b3b52abcb2476) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 21 Oct 2024 and was reviewed by Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342612](https://bugs.openjdk.org/browse/JDK-8342612) needs maintainer approval

### Issue
 * [JDK-8342612](https://bugs.openjdk.org/browse/JDK-8342612): Increase memory usage of compiler/c2/TestScalarReplacementMaxLiveNodes.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/200/head:pull/200` \
`$ git checkout pull/200`

Update a local copy of the PR: \
`$ git checkout pull/200` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 200`

View PR using the GUI difftool: \
`$ git pr show -t 200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/200.diff">https://git.openjdk.org/jdk23u/pull/200.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/200#issuecomment-2425850437)