### PR TITLE
8324672: Update jdk/java/time/tck/java/time/TCKInstant.java now() to be more robust

### DIFF
--- a/test/jdk/java/time/tck/java/time/TCKInstant.java
+++ b/test/jdk/java/time/tck/java/time/TCKInstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,10 +187,21 @@ public class TCKInstant extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     @Test
     public void now() {
-        Instant expected = Instant.now(Clock.systemUTC());
-        Instant test = Instant.now();
-        long diff = Math.abs(test.toEpochMilli() - expected.toEpochMilli());
-        assertTrue(diff < 100);  // less than 0.1 secs
+        long beforeMillis, instantMillis, afterMillis, diff;
+        int retryRemaining = 5; // MAX_RETRY_COUNT
+        do {
+            beforeMillis = Instant.now(Clock.systemUTC()).toEpochMilli();
+            instantMillis = Instant.now().toEpochMilli();
+            afterMillis = Instant.now(Clock.systemUTC()).toEpochMilli();
+            diff = instantMillis - beforeMillis;
+            if (instantMillis < beforeMillis || instantMillis > afterMillis) {
+                throw new RuntimeException(": Invalid instant: (~" + instantMillis + "ms)"
+                        + " when systemUTC in millis is in ["
+                        + beforeMillis + ", "
+                        + afterMillis + "]");
+            }
+        } while (diff > 100 && --retryRemaining > 0);  // retry if diff more than 0.1 sec
+        assertTrue(retryRemaining > 0);
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Straight Backport. Test passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324672](https://bugs.openjdk.org/browse/JDK-8324672) needs maintainer approval

### Issue
 * [JDK-8324672](https://bugs.openjdk.org/browse/JDK-8324672): Update jdk/java/time/tck/java/time/TCKInstant.java now() to be more robust (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/205.diff">https://git.openjdk.org/jdk23u/pull/205.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/205#issuecomment-2434367648)