### PR TITLE
8337968: Problem list compiler/vectorapi/VectorRebracket128Test.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -74,6 +74,8 @@ compiler/codecache/CheckLargePages.java 8332654 linux-x64
 
 compiler/vectorapi/reshape/TestVectorReinterpret.java 8320897 aix-ppc64,linux-ppc64le
 compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x64
+compiler/vectorapi/VectorRebracket128Test.java#ZSinglegen 8330538 generic-all
+compiler/vectorapi/VectorRebracket128Test.java#ZGenerational 8330538 generic-all
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/DataPatchTest.java 8331704 linux-riscv64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [66286b25](https://github.com/openjdk/jdk/commit/66286b25a183de2ffd0689da9c2bd1978b881aa7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Tobias Hartmann on 7 Aug 2024 and was reviewed by Christian Hagedorn.

The reason for the backport is intermittent failures seen on the jdk23u CI pipeline.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337968](https://bugs.openjdk.org/browse/JDK-8337968) needs maintainer approval

### Issue
 * [JDK-8337968](https://bugs.openjdk.org/browse/JDK-8337968): Problem list compiler/vectorapi/VectorRebracket128Test.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/206/head:pull/206` \
`$ git checkout pull/206`

Update a local copy of the PR: \
`$ git checkout pull/206` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 206`

View PR using the GUI difftool: \
`$ git pr show -t 206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/206.diff">https://git.openjdk.org/jdk23u/pull/206.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/206#issuecomment-2435224566)