### PR TITLE
8342489: compiler/c2/irTests/TestVectorizationMismatchedAccess.java fails on big-endian platforms

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -50,9 +50,6 @@ public class TestVectorizationMismatchedAccess {
     private final static WhiteBox wb = WhiteBox.getWhiteBox();
 
     public static void main(String[] args) {
-        if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-            throw new RuntimeException("fix test that was written for a little endian platform");
-        }
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
     }
 
@@ -75,6 +72,14 @@ public class TestVectorizationMismatchedAccess {
                 verifyLongArray[i] = verifyLongArray[i] | (((long)verifyByteArray[8 * i + j]) << 8 * j);
             }
         }
+    }
+
+    // Method to adjust the value for the native byte order
+    static private long handleByteOrder(long value) {
+        if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+            value = Long.reverseBytes(value);
+        }
+        return value;
     }
 
     static private void runAndVerify(Runnable test, int offset) {
@@ -154,7 +159,7 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong1a(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i, src[i]);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i, handleByteOrder(src[i]));
         }
     }
 
@@ -165,7 +170,7 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong1b(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * i, src[i]);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * i, handleByteOrder(src[i]));
         }
     }
 
@@ -175,7 +180,7 @@ public class TestVectorizationMismatchedAccess {
     public static void testByteLong1c(byte[] dest, long[] src) {
         long base = 64; // make sure it is big enough and 8 byte aligned (required for 32-bit)
         for (int i = 0; i < src.length - 8; i++) {
-            UNSAFE.putLongUnaligned(dest, base + 8 * i, src[i]);
+            UNSAFE.putLongUnaligned(dest, base + 8 * i, handleByteOrder(src[i]));
         }
     }
 
@@ -187,7 +192,7 @@ public class TestVectorizationMismatchedAccess {
     public static void testByteLong1d(byte[] dest, long[] src) {
         long base = 64; // make sure it is big enough and 8 byte aligned (required for 32-bit)
         for (int i = 0; i < src.length - 8; i++) {
-            UNSAFE.putLongUnaligned(dest, base + 8L * i, src[i]);
+            UNSAFE.putLongUnaligned(dest, base + 8L * i, handleByteOrder(src[i]));
         }
     }
 
@@ -207,7 +212,7 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong2a(byte[] dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i - 1), src[i]);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i - 1), handleByteOrder(src[i]));
         }
     }
 
@@ -218,7 +223,7 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong2b(byte[] dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i - 1), src[i]);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i - 1), handleByteOrder(src[i]));
         }
     }
 
@@ -236,7 +241,7 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong3a(byte[] dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + 1), src[i]);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + 1), handleByteOrder(src[i]));
         }
     }
 
@@ -247,7 +252,7 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong3b(byte[] dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + 1), src[i]);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + 1), handleByteOrder(src[i]));
         }
     }
 
@@ -267,7 +272,7 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testByteLong4a(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(dest, 8 * i + baseOffset, src[i]);
+            UNSAFE.putLongUnaligned(dest, 8 * i + baseOffset, handleByteOrder(src[i]));
         }
     }
 
@@ -280,7 +285,7 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testByteLong4b(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(dest, 8L * i + baseOffset, src[i]);
+            UNSAFE.putLongUnaligned(dest, 8L * i + baseOffset, handleByteOrder(src[i]));
         }
     }
 
@@ -299,7 +304,7 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong5a(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + baseOffset), src[i]);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + baseOffset), handleByteOrder(src[i]));
         }
     }
 
@@ -310,7 +315,7 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong5b(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + baseOffset), src[i]);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + baseOffset), handleByteOrder(src[i]));
         }
     }
 
@@ -454,7 +459,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong1a(long dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8 * i, src[i]);
+            UNSAFE.putLongUnaligned(null, dest + 8 * i, handleByteOrder(src[i]));
         }
     }
 
@@ -465,7 +470,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong1b(long dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8L * i, src[i]);
+            UNSAFE.putLongUnaligned(null, dest + 8L * i, handleByteOrder(src[i]));
         }
     }
 
@@ -482,7 +487,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong2a(long dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8 * (i - 1), src[i]);
+            UNSAFE.putLongUnaligned(null, dest + 8 * (i - 1), handleByteOrder(src[i]));
         }
     }
 
@@ -493,7 +498,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong2b(long dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8L * (i - 1), src[i]);
+            UNSAFE.putLongUnaligned(null, dest + 8L * (i - 1), handleByteOrder(src[i]));
         }
     }
 
@@ -510,7 +515,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong3a(long dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8 * (i + 1), src[i]);
+            UNSAFE.putLongUnaligned(null, dest + 8 * (i + 1), handleByteOrder(src[i]));
         }
     }
 
@@ -521,7 +526,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong3b(long dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8L * (i + 1), src[i]);
+            UNSAFE.putLongUnaligned(null, dest + 8L * (i + 1), handleByteOrder(src[i]));
         }
     }
 
@@ -540,7 +545,7 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testOffHeapLong4a(long dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8 * i + baseOffset, src[i]);
+            UNSAFE.putLongUnaligned(null, dest + 8 * i + baseOffset, handleByteOrder(src[i]));
         }
     }
 
@@ -553,7 +558,7 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testOffHeapLong4b(long dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8L * i + baseOffset, src[i]);
+            UNSAFE.putLongUnaligned(null, dest + 8L * i + baseOffset, handleByteOrder(src[i]));
         }
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b6f745df](https://github.com/openjdk/jdk/commit/b6f745df5795341dab1fc049a188a9e70d563a1a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Amit Kumar on 30 Oct 2024 and was reviewed by Emanuel Peter and Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8342489](https://bugs.openjdk.org/browse/JDK-8342489) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342489](https://bugs.openjdk.org/browse/JDK-8342489): compiler/c2/irTests/TestVectorizationMismatchedAccess.java fails on big-endian platforms (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/211/head:pull/211` \
`$ git checkout pull/211`

Update a local copy of the PR: \
`$ git checkout pull/211` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 211`

View PR using the GUI difftool: \
`$ git pr show -t 211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/211.diff">https://git.openjdk.org/jdk23u/pull/211.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/211#issuecomment-2445763266)
</details>
