### PR TITLE
8207908: JMXStatusTest.java fails assertion intermittently

### DIFF
--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,8 +88,6 @@ abstract public class JMXStatusTest {
         args.addAll(getCustomVmArgs());
         args.add(TEST_APP_NAME);
         testAppPb = ProcessTools.createTestJavaProcessBuilder(args);
-
-        jcmd = new ManagementAgentJcmd(TEST_APP_NAME, false);
     }
 
     @BeforeMethod
@@ -98,6 +96,7 @@ abstract public class JMXStatusTest {
             TEST_APP_NAME, testAppPb,
             (Predicate<String>)l->l.trim().equals("main enter")
         );
+        jcmd = new ManagementAgentJcmd(testApp, false);
     }
 
     @AfterMethod

--- a/test/jdk/sun/management/jmxremote/startstop/ManagementAgentJcmd.java
+++ b/test/jdk/sun/management/jmxremote/startstop/ManagementAgentJcmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,11 +47,11 @@ final class ManagementAgentJcmd {
     private static final String CMD_STATUS = "ManagementAgent.status";
     private static final String CMD_PRINTPERF = "PerfCounter.print";
 
-    private final String id;
+    private final long pid;
     private final boolean verbose;
 
-    public ManagementAgentJcmd(String targetApp, boolean verbose) {
-        this.id = targetApp;
+    public ManagementAgentJcmd(Process targetApp, boolean verbose) {
+        this.pid = targetApp.pid();
         this.verbose = verbose;
     }
 
@@ -174,7 +174,7 @@ final class ManagementAgentJcmd {
      * @throws InterruptedException
      */
     private String jcmd(Consumer<String> c, String ... command) throws IOException, InterruptedException {
-        return jcmd(id, c, command);
+        return jcmd(Long.toString(pid), c, command);
     }
 
     /**


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b7d0eff5](https://github.com/openjdk/jdk/commit/b7d0eff5ad77e338b237773d2fc047eea3d2ac12) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Kevin Walls on 11 Jul 2024 and was reviewed by Chris Plummer and Alex Menkov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8207908](https://bugs.openjdk.org/browse/JDK-8207908) needs maintainer approval

### Issue
 * [JDK-8207908](https://bugs.openjdk.org/browse/JDK-8207908): JMXStatusTest.java fails assertion intermittently (**Bug** - P3 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/215.diff">https://git.openjdk.org/jdk23u/pull/215.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/215#issuecomment-2456431026)
</details>
