### PR TITLE
8340586: JdkJfrEvent::get_all_klasses stores non-strong oops in JNI handles

### DIFF
--- a/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
@@ -35,6 +35,7 @@
 #include "oops/klass.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaThread.hpp"
+#include "runtime/safepointVerifiers.hpp"
 #include "utilities/stack.inline.hpp"
 
 static jobject empty_java_util_arraylist = nullptr;
@@ -80,27 +81,22 @@ static bool is_allowed(const Klass* k) {
   return !(k->is_abstract() || k->should_be_initialized());
 }
 
-static void fill_klasses(GrowableArray<const void*>& event_subklasses, const InstanceKlass* event_klass, JavaThread* thread) {
+static void fill_klasses(GrowableArray<jclass>& event_subklasses, const InstanceKlass* event_klass, JavaThread* thread) {
   assert(event_subklasses.length() == 0, "invariant");
   assert(event_klass != nullptr, "invariant");
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(thread));
+  // Do not safepoint while walking the ClassHierarchy, keeping klasses alive and storing their mirrors in JNI handles.
+  NoSafepointVerifier nsv;
 
   for (ClassHierarchyIterator iter(const_cast<InstanceKlass*>(event_klass)); !iter.done(); iter.next()) {
     Klass* subk = iter.klass();
     if (is_allowed(subk)) {
-      event_subklasses.append(subk);
+      // We are walking the class hierarchy and saving the relevant klasses in JNI handles.
+      // To be allowed to store the java mirror, we must ensure that the klass and its oops are kept alive,
+      // and perform the store before the next safepoint.
+      subk->keep_alive();
+      event_subklasses.append((jclass)JfrJavaSupport::local_jni_handle(subk->java_mirror(), thread));
     }
-  }
-}
-
-static void transform_klasses_to_local_jni_handles(GrowableArray<const void*>& event_subklasses, JavaThread* thread) {
-  assert(event_subklasses.is_nonempty(), "invariant");
-  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(thread));
-
-  for (int i = 0; i < event_subklasses.length(); ++i) {
-    const InstanceKlass* k = static_cast<const InstanceKlass*>(event_subklasses.at(i));
-    assert(is_allowed(k), "invariant");
-    event_subklasses.at_put(i, JfrJavaSupport::local_jni_handle(k->java_mirror(), thread));
   }
 }
 
@@ -126,14 +122,12 @@ jobject JdkJfrEvent::get_all_klasses(TRAPS) {
   }
 
   ResourceMark rm(THREAD);
-  GrowableArray<const void*> event_subklasses(initial_array_size);
+  GrowableArray<jclass> event_subklasses(initial_array_size);
   fill_klasses(event_subklasses, InstanceKlass::cast(klass), THREAD);
 
   if (event_subklasses.is_empty()) {
     return empty_java_util_arraylist;
   }
-
-  transform_klasses_to_local_jni_handles(event_subklasses, THREAD);
 
   Handle h_array_list(THREAD, new_java_util_arraylist(THREAD));
   assert(h_array_list.not_null(), "invariant");
@@ -150,7 +144,7 @@ jobject JdkJfrEvent::get_all_klasses(TRAPS) {
 
   JavaValue result(T_BOOLEAN);
   for (int i = 0; i < event_subklasses.length(); ++i) {
-    const jclass clazz = (jclass)event_subklasses.at(i);
+    const jclass clazz = event_subklasses.at(i);
     assert(JdkJfrEvent::is_subklass(clazz), "invariant");
     JfrJavaArguments args(&result, array_list_klass, add_method_sym, add_method_sig_sym);
     args.set_receiver(h_array_list());

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -582,6 +582,8 @@ protected:
 
   inline oop klass_holder() const;
 
+  inline void keep_alive() const;
+
  protected:
 
   // Error handling when length > max_length or length < 0

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -36,6 +36,13 @@ inline oop Klass::klass_holder() const {
   return class_loader_data()->holder();
 }
 
+inline void Klass::keep_alive() const {
+  // Resolving the holder (a WeakHandle) will keep the klass alive until the next safepoint.
+  // Making the klass's CLD handle oops (e.g. the java_mirror), safe to store in the object
+  // graph and its roots (e.g. Handles).
+  static_cast<void>(klass_holder());
+}
+
 inline bool Klass::is_non_strong_hidden() const {
   return access_flags().is_hidden_class() &&
          class_loader_data()->has_class_mirror_holder();
@@ -52,6 +59,7 @@ inline bool Klass::is_loader_alive() const {
   return class_loader_data()->is_alive();
 }
 
+// Loading the java_mirror does not keep its holder alive. See Klass::keep_alive().
 inline oop Klass::java_mirror() const {
   return _java_mirror.resolve();
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [97b681e9](https://github.com/openjdk/jdk/commit/97b681e93a9469d8d16122dc10bbf2f5b5fe2266) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Axel Boldt-Christmas on 7 Nov 2024 and was reviewed by Coleen Phillimore, Stefan Karlsson and Markus Grönlund.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340586](https://bugs.openjdk.org/browse/JDK-8340586) needs maintainer approval

### Issue
 * [JDK-8340586](https://bugs.openjdk.org/browse/JDK-8340586): JdkJfrEvent::get_all_klasses stores non-strong oops in JNI handles (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/218/head:pull/218` \
`$ git checkout pull/218`

Update a local copy of the PR: \
`$ git checkout pull/218` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 218`

View PR using the GUI difftool: \
`$ git pr show -t 218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/218.diff">https://git.openjdk.org/jdk23u/pull/218.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/218#issuecomment-2461938109)
</details>
