### PR TITLE
8336012: Fix usages of jtreg-reserved properties

### DIFF
--- a/test/jdk/java/lang/invoke/PrivateInvokeTest.java
+++ b/test/jdk/java/lang/invoke/PrivateInvokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,8 +67,6 @@ public class PrivateInvokeTest {
         String vstr = System.getProperty(THIS_CLASS.getSimpleName()+".verbose");
         if (vstr == null)
             vstr = System.getProperty(THIS_CLASS.getName()+".verbose");
-        if (vstr == null)
-            vstr = System.getProperty("test.verbose");
         if (vstr != null)  verbose = Integer.parseInt(vstr);
     }
     private static int referenceKind(Method m) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e6c5aa7a](https://github.com/openjdk/jdk/commit/e6c5aa7a6cb54c647d261facdcffa6a410849627) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

`test/jdk/java/lang/invoke/PrivateInvokeTest.java` is failing on s390x JDK23 - CI consistently. error: 

```
STDERR:
STARTED    test.java.lang.invoke.PrivateInvokeTest::testFirst 'testFirst'
java.lang.NumberFormatException: For input string: "Verbose[p=SUMMARY,f=FULL,e=FULL,t=false,m=false]"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:588)
	at java.base/java.lang.Integer.parseInt(Integer.java:685)
	at test.java.lang.invoke.PrivateInvokeTest.<init>(PrivateInvokeTest.java:72)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:501)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:485)
FAILED     test.java.lang.invoke.PrivateInvokeTest::testFirst 'testFirst' [60ms]
STARTED    test.java.lang.invoke.PrivateInvokeTest::testInvokeDirect 'testInvokeDirect'
java.lang.NumberFormatException: For input string: "Verbose[p=SUMMARY,f=FULL,e=FULL,t=false,m=false]"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:588)
	at java.base/java.lang.Integer.parseInt(Integer.java:685)
	at test.java.lang.invoke.PrivateInvokeTest.<init>(PrivateInvokeTest.java:72)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:501)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:485)
FAILED     test.java.lang.invoke.PrivateInvokeTest::testInvokeDirect 'testInvokeDirect' [4ms]
JavaTest Message: JUnit Platform Failure(s): 2

[ JUnit Containers: found 4, started 4, succeeded 4, failed 0, aborted 0, skipped 0]
[ JUnit Tests: found 2, started 2, succeeded 0, failed 2, aborted 0, skipped 0]

java.lang.Exception: JUnit test failure
	at com.sun.javatest.regtest.agent.JUnitRunner.runWithJUnitPlatform(JUnitRunner.java:155)
	at com.sun.javatest.regtest.agent.JUnitRunner.main(JUnitRunner.java:99)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:333)
	at java.base/java.lang.Thread.run(Thread.java:1575)

JavaTest Message: Test threw exception: java.lang.Exception
JavaTest Message: shutting down test
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336012](https://bugs.openjdk.org/browse/JDK-8336012) needs maintainer approval

### Issue
 * [JDK-8336012](https://bugs.openjdk.org/browse/JDK-8336012): Fix usages of jtreg-reserved properties (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/222/head:pull/222` \
`$ git checkout pull/222`

Update a local copy of the PR: \
`$ git checkout pull/222` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 222`

View PR using the GUI difftool: \
`$ git pr show -t 222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/222.diff">https://git.openjdk.org/jdk23u/pull/222.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/222#issuecomment-2469505439)
</details>
