### PR TITLE
8337339: gc/arguments/Test*SizeFlags.java timing out with Xcomp

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @summary Tests argument processing for initial and maximum heap size for the G1 collector
  * @key flag-sensitive
  * @requires vm.gc.G1 & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
@@ -30,6 +30,7 @@ package gc.arguments;
  * parallel collectors.
  * @key flag-sensitive
  * @requires vm.gc.Parallel & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @summary Tests argument processing for initial and maximum heap size for the Serial collector
  * @key flag-sensitive
  * @requires vm.gc.Serial & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Clean backport. disabling these tests in Xcomp. Tested in mach5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8337339](https://bugs.openjdk.org/browse/JDK-8337339) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337339](https://bugs.openjdk.org/browse/JDK-8337339): gc/arguments/Test*SizeFlags.java timing out with Xcomp (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/224.diff">https://git.openjdk.org/jdk23u/pull/224.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/224#issuecomment-2469914175)
</details>
