### PR TITLE
8342409: [s390x] C1 unwind_handler fails to unlock synchronized methods with LM_MONITOR

### DIFF
--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -230,7 +230,11 @@ int LIR_Assembler::emit_unwind_handler() {
     LIR_Opr lock = FrameMap::as_opr(Z_R1_scratch);
     monitor_address(0, lock);
     stub = new MonitorExitStub(lock, true, 0);
-    __ unlock_object(Rtmp1, Rtmp2, lock->as_register(), *stub->entry());
+    if (LockingMode == LM_MONITOR) {
+      __ branch_optimized(Assembler::bcondAlways, *stub->entry());
+    } else {
+      __ unlock_object(Rtmp1, Rtmp2, lock->as_register(), *stub->entry());
+    }
     __ bind(*stub->continuation());
   }
 

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -119,6 +119,8 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
     branch_optimized(Assembler::bcondNotZero, slow_case);
     // done
     bind(done);
+  } else {
+    assert(false, "Unhandled LockingMode:%d", LockingMode);
   }
 }
 
@@ -155,6 +157,8 @@ void C1_MacroAssembler::unlock_object(Register Rmark, Register Roop, Register Rb
     // If the object header was not pointing to the displaced header,
     // we do unlocking via runtime call.
     branch_optimized(Assembler::bcondNotEqual, slow_case);
+  } else {
+    assert(false, "Unhandled LockingMode:%d", LockingMode);
   }
   // done
   bind(done);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9201e9fc](https://github.com/openjdk/jdk/commit/9201e9fcc28cff37cf9996e8db38f9aee7511b1c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Amit Kumar on 18 Oct 2024 and was reviewed by Richard Reingruber and Lutz Schmidt.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342409](https://bugs.openjdk.org/browse/JDK-8342409) needs maintainer approval

### Issue
 * [JDK-8342409](https://bugs.openjdk.org/browse/JDK-8342409): [s390x] C1 unwind_handler fails to unlock synchronized methods with LM_MONITOR (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/229/head:pull/229` \
`$ git checkout pull/229`

Update a local copy of the PR: \
`$ git checkout pull/229` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 229`

View PR using the GUI difftool: \
`$ git pr show -t 229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/229.diff">https://git.openjdk.org/jdk23u/pull/229.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/229#issuecomment-2503217872)
</details>
