### PR TITLE
8340552: Harden TzdbZoneRulesCompiler against missing zone names

### DIFF
--- a/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
+++ b/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -273,7 +273,7 @@ public final class TzdbZoneRulesCompiler {
             // link version-region-rules
             out.writeShort(builtZones.size());
             for (Map.Entry<String, ZoneRules> entry : builtZones.entrySet()) {
-                 int regionIndex = Arrays.binarySearch(regionArray, entry.getKey());
+                 int regionIndex = findRegionIndex(regionArray, entry.getKey());
                  int rulesIndex = rulesList.indexOf(entry.getValue());
                  out.writeShort(regionIndex);
                  out.writeShort(rulesIndex);
@@ -281,8 +281,8 @@ public final class TzdbZoneRulesCompiler {
             // alias-region
             out.writeShort(links.size());
             for (Map.Entry<String, String> entry : links.entrySet()) {
-                 int aliasIndex = Arrays.binarySearch(regionArray, entry.getKey());
-                 int regionIndex = Arrays.binarySearch(regionArray, entry.getValue());
+                 int aliasIndex = findRegionIndex(regionArray, entry.getKey());
+                 int regionIndex = findRegionIndex(regionArray, entry.getValue());
                  out.writeShort(aliasIndex);
                  out.writeShort(regionIndex);
             }
@@ -292,6 +292,14 @@ public final class TzdbZoneRulesCompiler {
             ex.printStackTrace();
             System.exit(1);
         }
+    }
+
+    private static int findRegionIndex(String[] regionArray, String region) {
+        int index = Arrays.binarySearch(regionArray, region);
+        if (index < 0) {
+            throw new IllegalArgumentException("Unknown region: " + region);
+        }
+        return index;
     }
 
     /** Whether to output verbose messages. */


### PR DESCRIPTION
Clean backport of JDK-8340552.

Tested tier1 tests and processing data from tzdata/2024b.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8340552](https://bugs.openjdk.org/browse/JDK-8340552) needs maintainer approval

### Issue
 * [JDK-8340552](https://bugs.openjdk.org/browse/JDK-8340552): Harden TzdbZoneRulesCompiler against missing zone names (**Bug** - P5 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/230/head:pull/230` \
`$ git checkout pull/230`

Update a local copy of the PR: \
`$ git checkout pull/230` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 230`

View PR using the GUI difftool: \
`$ git pr show -t 230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/230.diff">https://git.openjdk.org/jdk23u/pull/230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/230#issuecomment-2505951372)
</details>
