### PR TITLE
8344589: Update IANA Language Subtag Registry to Version 2024-11-19

### DIFF
--- a/src/java.base/share/data/lsrdata/language-subtag-registry.txt
+++ b/src/java.base/share/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2024-06-14
+File-Date: 2024-11-19
 %%
 Type: language
 Subtag: aa
@@ -47989,6 +47989,16 @@ Subtag: kkcor
 Description: Common Cornish orthography of Revived Cornish
 Added: 2008-10-14
 Prefix: kw
+%%
+Type: variant
+Subtag: kleinsch
+Description: Kleinschmidt orthography
+Description: Allattaasitaamut
+Added: 2024-07-20
+Prefix: kl
+Prefix: kl-tunumiit
+Comments: Orthography for Greenlandic designed by Samuel Kleinschmidt,
+  used from 1851 to 1973.
 %%
 Type: variant
 Subtag: kociewie

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8025703 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  *      8258795 8267038 8287180 8302512 8304761 8306031 8308021 8313702 8318322
- *      8327631 8332424 8334418
+ *      8327631 8332424 8334418 8344589
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2024-06-14) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2024-11-19) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
Backport of JDK-8344589 - Update IANA Language Subtag Registry to Version 2024-11-19

Clean backport. 
Passed tier1 tests.  There are the same failures as in that master branch:

````
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg:tier1                     2579  2579     0     0   
>> jtreg:test/jdk:tier1                               2413  2392    21     0 <<
>> jtreg:test/langtools:tier1                         4543  4473    70     0 <<
   jtreg:test/jaxp:tier1                                 0     0     0     0   
   jtreg:test/lib-test:tier1                            33    33     0     0   
==============================
TEST FAILURE
````
Passed gtests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8344589](https://bugs.openjdk.org/browse/JDK-8344589) needs maintainer approval

### Issue
 * [JDK-8344589](https://bugs.openjdk.org/browse/JDK-8344589): Update IANA Language Subtag Registry to Version 2024-11-19 (**Enhancement** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/234/head:pull/234` \
`$ git checkout pull/234`

Update a local copy of the PR: \
`$ git checkout pull/234` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 234`

View PR using the GUI difftool: \
`$ git pr show -t 234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/234.diff">https://git.openjdk.org/jdk23u/pull/234.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/234#issuecomment-2582829948)
</details>
