### PR TITLE
8211851: (ch) java/nio/channels/AsynchronousSocketChannel/StressLoopback.java times out (aix)

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -559,8 +559,6 @@ java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc6
 
 # jdk_nio
 
-java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
-
 java/nio/channels/Channels/SocketChannelStreams.java            8317838 aix-ppc64
 
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8308807 aix-ppc64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8b22517c](https://github.com/openjdk/jdk/commit/8b22517cb0b24c4134a2dbf22591f6f84d7d866c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Joachim Kern on 7 Jan 2025 and was reviewed by Martin Doerr and Varada M.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8211851](https://bugs.openjdk.org/browse/JDK-8211851) needs maintainer approval

### Issue
 * [JDK-8211851](https://bugs.openjdk.org/browse/JDK-8211851): (ch) java/nio/channels/AsynchronousSocketChannel/StressLoopback.java times out (aix) (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk23u.git pull/235/head:pull/235` \
`$ git checkout pull/235`

Update a local copy of the PR: \
`$ git checkout pull/235` \
`$ git pull https://git.openjdk.org/jdk23u.git pull/235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 235`

View PR using the GUI difftool: \
`$ git pr show -t 235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk23u/pull/235.diff">https://git.openjdk.org/jdk23u/pull/235.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk23u/pull/235#issuecomment-2589368795)
</details>
